### PR TITLE
ENDOC-58 remove sample app refs

### DIFF
--- a/vuepress/docs/next/docs/reference/entando-apis.md
+++ b/vuepress/docs/next/docs/reference/entando-apis.md
@@ -12,9 +12,9 @@ sidebarDepth: 0
 
 ## Setup
 
-1.  Clone the Entando sample app if you don’t already have it.
+1.  Clone the Entando reference app if you don’t already have it.
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
 2.  Start the app for local execution and enable the swagger profile by
     passing `-Dspring.profiles.active=swagger` to the jetty command. Set
@@ -29,7 +29,7 @@ sidebarDepth: 0
 
 <!-- -->
 
-    http://localhost:[your port]/entando-sample-app/api/swagger-ui.html
+    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
 
 ## Overview
 
@@ -72,7 +72,7 @@ API endpoints can be found.
         `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
 
 4.  Login to the admin console at
-    <http://localhost:8085/entando-sample-app/do/login>.
+    <http://localhost:8085/entando-de-app/do/login>.
 
 5.  Once logged in go to Integration -→ API Management -→ Consumers.
 
@@ -85,7 +85,7 @@ API endpoints can be found.
 9.  Hit save
 
 10. Return to swagger [your
-    port](http://localhost:)/entando-sample-app/api/swagger-ui.html
+    port](http://localhost:)/entando-de-app/api/swagger-ui.html
 
 11. Hit authorize
 
@@ -108,5 +108,3 @@ API endpoints can be found.
     -   Select **Try it out**
 
     -   Look at the results in the window
-
-

--- a/vuepress/docs/next/tutorials/customize-the-platform/app-engine/build-core-image.md
+++ b/vuepress/docs/next/tutorials/customize-the-platform/app-engine/build-core-image.md
@@ -17,18 +17,18 @@ This tutorial will take you through the basic steps to create a docker
 image from an Entando core application. A more detailed guide with
 additional commands and configuration can be found here:
 
-<https://github.com/entando-k8s/entando-sample-app>
+<https://github.com/entando-k8s/entando-de-app>
 
 ## Setup
 
 1.  Clone the application at:
-    <https://github.com/entando-k8s/entando-sample-app> using
+    <https://github.com/entando-k8s/entando-de-app> using
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
-        cd entando-sample-app
+        cd entando-de-app
 
 3.  Build a docker image from the core app
 
@@ -40,17 +40,15 @@ additional commands and configuration can be found here:
 
     Look for
 
-        entando/entando-sample-app:latest
+        entando/entando-de-app:latest
 
 5.  Create a repository on your docker repository to house your new
     application
 
 6.  Re-tag the image you just built with your repo
 
-         docker tag entando/entando-sample-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
+         docker tag entando/entando-de-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
 
 7.  Push the Image to your Repository
 
         docker push <YOUR-USER>/<YOUR-REPO-NAME>:latest
-
-

--- a/vuepress/docs/next/tutorials/customize-the-platform/app-engine/building-prepackaged-image.md
+++ b/vuepress/docs/next/tutorials/customize-the-platform/app-engine/building-prepackaged-image.md
@@ -27,7 +27,7 @@ deploy it as a new application.
 
         git clone https://github.com/entando/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
         cd entando-de-app
 

--- a/vuepress/docs/next/tutorials/customize-the-platform/app-engine/core-swagger.md
+++ b/vuepress/docs/next/tutorials/customize-the-platform/app-engine/core-swagger.md
@@ -10,7 +10,7 @@
 
 1.  Clone the Entando sample app if you don’t already have it.
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
 2.  Start the app for local execution and enable the swagger profile by
     passing `-Dspring.profiles.active=swagger` to the jetty command. Set
@@ -25,7 +25,7 @@
 
 <!-- -->
 
-    http://localhost:[your port]/entando-sample-app/api/swagger-ui.html
+    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
 
 ## Overview
 
@@ -68,7 +68,7 @@ API endpoints can be found.
         `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
 
 4.  Login to the admin console at
-    <http://localhost:8085/entando-sample-app/do/login>.
+    <http://localhost:8085/entando-de-app/do/login>.
 
 5.  Once logged in go to Integration -→ API Management -→ Consumers.
 
@@ -81,7 +81,7 @@ API endpoints can be found.
 9.  Hit save
 
 10. Return to swagger [your
-    port](http://localhost:)/entando-sample-app/api/swagger-ui.html
+    port](http://localhost:)/entando-de-app/api/swagger-ui.html
 
 11. Hit authorize
 

--- a/vuepress/docs/next/tutorials/devops/build-core-image.md
+++ b/vuepress/docs/next/tutorials/devops/build-core-image.md
@@ -17,18 +17,18 @@ This tutorial will take you through the basic steps to create a docker
 image from an Entando core application. A more detailed guide with
 additional commands and configuration can be found here:
 
-<https://github.com/entando-k8s/entando-sample-app>
+<https://github.com/entando-k8s/entando-de-app>
 
 ## Setup
 
 1.  Clone the application at:
-    <https://github.com/entando-k8s/entando-sample-app> using
+    <https://github.com/entando-k8s/entando-de-app> using
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
-        cd entando-sample-app
+        cd entando-de-app
 
 3.  Build a docker image from the core app
 
@@ -40,14 +40,14 @@ additional commands and configuration can be found here:
 
     Look for
 
-        entando/entando-sample-app:latest
+        entando/entando-de-app:latest
 
 5.  Create a repository on your docker repository to house your new
     application
 
 6.  Re-tag the image you just built with your repo
 
-         docker tag entando/entando-sample-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
+         docker tag entando/entando-de-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
 
 7.  Push the Image to your Repository
 

--- a/vuepress/docs/v6.1/docs/reference/core-swagger.md
+++ b/vuepress/docs/v6.1/docs/reference/core-swagger.md
@@ -10,7 +10,7 @@
 
 1.  Clone the Entando sample app if you don’t already have it.
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
 2.  Start the app for local execution and enable the swagger profile by
     passing `-Dspring.profiles.active=swagger` to the jetty command. Set
@@ -25,7 +25,7 @@
 
 <!-- -->
 
-    http://localhost:[your port]/entando-sample-app/api/swagger-ui.html
+    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
 
 ## Overview
 
@@ -68,7 +68,7 @@ API endpoints can be found.
         `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
 
 4.  Login to the admin console at
-    <http://localhost:8085/entando-sample-app/do/login>.
+    <http://localhost:8085/entando-de-app/do/login>.
 
 5.  Once logged in go to Integration -→ API Management -→ Consumers.
 
@@ -81,7 +81,7 @@ API endpoints can be found.
 9.  Hit save
 
 10. Return to swagger [your
-    port](http://localhost:)/entando-sample-app/api/swagger-ui.html
+    port](http://localhost:)/entando-de-app/api/swagger-ui.html
 
 11. Hit authorize
 

--- a/vuepress/docs/v6.1/docs/reference/entando-apis.md
+++ b/vuepress/docs/v6.1/docs/reference/entando-apis.md
@@ -14,7 +14,7 @@ sidebarDepth: 0
 
 1.  Clone the Entando sample app if you don’t already have it.
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
 2.  Start the app for local execution and enable the swagger profile by
     passing `-Dspring.profiles.active=swagger` to the jetty command. Set
@@ -29,7 +29,7 @@ sidebarDepth: 0
 
 <!-- -->
 
-    http://localhost:[your port]/entando-sample-app/api/swagger-ui.html
+    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
 
 ## Overview
 
@@ -72,7 +72,7 @@ API endpoints can be found.
         `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
 
 4.  Login to the admin console at
-    <http://localhost:8085/entando-sample-app/do/login>.
+    <http://localhost:8085/entando-de-app/do/login>.
 
 5.  Once logged in go to Integration -→ API Management -→ Consumers.
 
@@ -85,7 +85,7 @@ API endpoints can be found.
 9.  Hit save
 
 10. Return to swagger [your
-    port](http://localhost:)/entando-sample-app/api/swagger-ui.html
+    port](http://localhost:)/entando-de-app/api/swagger-ui.html
 
 11. Hit authorize
 

--- a/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/build-core-image.md
+++ b/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/build-core-image.md
@@ -17,18 +17,18 @@ This tutorial will take you through the basic steps to create a docker
 image from an Entando core application. A more detailed guide with
 additional commands and configuration can be found here:
 
-<https://github.com/entando-k8s/entando-sample-app>
+<https://github.com/entando-k8s/entando-de-app>
 
 ## Setup
 
 1.  Clone the application at:
-    <https://github.com/entando-k8s/entando-sample-app> using
+    <https://github.com/entando-k8s/entando-de-app> using
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
-        cd entando-sample-app
+        cd entando-de-app
 
 3.  Build a docker image from the core app
 
@@ -40,14 +40,14 @@ additional commands and configuration can be found here:
 
     Look for
 
-        entando/entando-sample-app:latest
+        entando/entando-de-app:latest
 
 5.  Create a repository on your docker repository to house your new
     application
 
 6.  Re-tag the image you just built with your repo
 
-         docker tag entando/entando-sample-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
+         docker tag entando/entando-de-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
 
 7.  Push the Image to your Repository
 

--- a/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/building-prepackaged-image.md
+++ b/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/building-prepackaged-image.md
@@ -27,7 +27,7 @@ deploy it as a new application.
 
         git clone https://github.com/entando/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
         cd entando-de-app
 
@@ -114,5 +114,3 @@ deploy it as a new application.
 19. Once deployed go to the app builder in your app
 
 20. Click Go To Homepage
-
-

--- a/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/core-swagger.md
+++ b/vuepress/docs/v6.1/tutorials/customize-the-platform/app-engine/core-swagger.md
@@ -10,7 +10,7 @@
 
 1.  Clone the Entando sample app if you don’t already have it.
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
 2.  Start the app for local execution and enable the swagger profile by
     passing `-Dspring.profiles.active=swagger` to the jetty command. Set
@@ -25,7 +25,7 @@
 
 <!-- -->
 
-    http://localhost:[your port]/entando-sample-app/api/swagger-ui.html
+    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
 
 ## Overview
 
@@ -68,7 +68,7 @@ API endpoints can be found.
         `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
 
 4.  Login to the admin console at
-    <http://localhost:8085/entando-sample-app/do/login>.
+    <http://localhost:8085/entando-de-app/do/login>.
 
 5.  Once logged in go to Integration -→ API Management -→ Consumers.
 
@@ -81,7 +81,7 @@ API endpoints can be found.
 9.  Hit save
 
 10. Return to swagger [your
-    port](http://localhost:)/entando-sample-app/api/swagger-ui.html
+    port](http://localhost:)/entando-de-app/api/swagger-ui.html
 
 11. Hit authorize
 

--- a/vuepress/docs/v6.1/tutorials/devops/build-core-image.md
+++ b/vuepress/docs/v6.1/tutorials/devops/build-core-image.md
@@ -17,18 +17,18 @@ This tutorial will take you through the basic steps to create a docker
 image from an Entando core application. A more detailed guide with
 additional commands and configuration can be found here:
 
-<https://github.com/entando-k8s/entando-sample-app>
+<https://github.com/entando-k8s/entando-de-app>
 
 ## Setup
 
 1.  Clone the application at:
-    <https://github.com/entando-k8s/entando-sample-app> using
+    <https://github.com/entando-k8s/entando-de-app> using
 
-        git clone https://github.com/entando-k8s/entando-sample-app
+        git clone https://github.com/entando-k8s/entando-de-app
 
-2.  On a command line, cd into the entando-sample-app you just cloned:
+2.  On a command line, cd into the entando-de-app you just cloned:
 
-        cd entando-sample-app
+        cd entando-de-app
 
 3.  Build a docker image from the core app
 
@@ -40,14 +40,14 @@ additional commands and configuration can be found here:
 
     Look for
 
-        entando/entando-sample-app:latest
+        entando/entando-de-app:latest
 
 5.  Create a repository on your docker repository to house your new
     application
 
 6.  Re-tag the image you just built with your repo
 
-         docker tag entando/entando-sample-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
+         docker tag entando/entando-de-app:latest <YOUR-USER>/<YOUR-REPO-NAME>:latest
 
 7.  Push the Image to your Repository
 


### PR DESCRIPTION
Updated the refs in 6.1 as well since the entando-sample-app would be equally broken there.