### PR TITLE
ENG-346 adds the default widget field in the page template descriptor

### DIFF
--- a/vuepress/docs/next/tutorials/ecr/ecr-bundle-details.md
+++ b/vuepress/docs/next/tutorials/ecr/ecr-bundle-details.md
@@ -173,6 +173,8 @@ Here is an example of a widget descriptor
             y1: 0
             x2: 11
             y2: 0
+          defaultWidget:
+            code: my-widget # the code of the widget to apply when using the button "apply default widgets"
 
         # A simplified way to define a Frame
         - pos: 1

--- a/vuepress/docs/next/tutorials/ecr/ecr-bundle-details.md
+++ b/vuepress/docs/next/tutorials/ecr/ecr-bundle-details.md
@@ -174,7 +174,7 @@ Here is an example of a widget descriptor
             x2: 11
             y2: 0
           defaultWidget:
-            code: my-widget # the code of the widget to apply when using the button "apply default widgets"
+            code: my-widget # the code of the widget to apply when using the button "apply default widgets" in the page configuration UI
 
         # A simplified way to define a Frame
         - pos: 1


### PR DESCRIPTION
Adds the `defaultWidget` field to  the page-template descriptor as now is supported in the API