### PR TITLE
Endoc 106 update documentation to note swagger ui is enabled by default in quickstart environment as of 6 2 1

### DIFF
--- a/vuepress/docs/next/docs/reference/entando-apis.md
+++ b/vuepress/docs/next/docs/reference/entando-apis.md
@@ -1,94 +1,80 @@
 ---
-sidebarDepth: 0
+sidebarDepth: 2
 ---
-
 # Accessing Entando APIs
 
 ## Overview
 
-Following the [quickstart guide](../getting-started/quick-reference.md), Entando comes with Swagger UI enabled out of the box.
-If you want to use Swagger UI in the local environment, proceed in the reading, otherwise you can directly go to step [Setup in the quickstart environment](#setup-in-the-quickstart-environment).
+Entando includes the Swagger UI in a Getting Started environment and is reachable at `/entando-de-app/api/swagger-ui.html`:
+
+    http://[your-host-name]/entando-de-app/api/swagger-ui.html
+
+## How to find your client secret
+You'll need your client credentials to execute the Entando APIs. 
+
+1. Login into your Keycloak instance
+
+2. Go to `Administration` -> `Clients`
+
+3. Select the desired client (e.g. in a Getting Started environment this is `quickstart-server`)
+
+4. Click on the `Credentials` tab to get the secret 
 
 ## Setup in local environment
 
-### Prerequisites
+You may prefer to run a local standalone Entando application for some tasks. You'll need Java 8, maven, and Keycloak for authentication.
 
--   Java 8
+### Configure Keycloak
 
--   maven
+Configure your Keycloak client in order to support Swagger UI. A Getting Started environment has this pre-configured.
 
-### Setup
+1. Login to your Keycloak instance
 
-1.  Clone the Entando reference app if you don’t already have it.
+2. Access the Administration console
+
+3. Click on `Clients` on the left bar and select your client (e.g. `quickstart-server`)
+
+4. Update the following values under `Settings`:
+    - Set `Valid Redirect URIs` to `http://localhost:[your port]/entando-de-app/*` or `*` to allow all redirect URIs.
+    - Set `Web Origins` to `http://localhost:[your port]` or `*` to accept all origins.
+
+### Start the Entando Application
+
+1.  Clone the Entando reference application:
 
         git clone https://github.com/entando-k8s/entando-de-app
 
-2.  Start the app for local execution and 
+2.  Start the application with the following options: 
     
-    - enable the swagger profile by passing `-Dspring.profiles.active=swagger` to the jetty command. Set
-    the value of `-Djetty.port` to something available on your machine e.g. 8085.
+    - Enable the Swagger profile via `-Dspring.profiles.active=swagger`
+    - Enable the Keycloak profile via `-Pkeycloak`
+    - Configure the application connection to Keycloak itself. For simplicity this uses the same client credentials you'll use to try out the APIs.
+       - Set `-Dkeycloak.auth.url` to your Keycloak endpoint (including `/auth`), e.g. `-Dkeycloak.auth.url=http://my-keycloak-server/auth`   
+       - Set `-Dkeycloak.client.id` to your client id, e.g. `-Dkeycloak.client.id=quickstart-server`
+       - Set `-Dkeycloak.client.secret` to your client secret, e.g. `-Dkeycloak.client.secret=my-secret`. See [How to find your client secret](#how-to-find-your-client-secret) above.
+    - (Optional) Set`-Djetty.port=8085` if the default port 8080 is already in use. 
+    - (Optional) To skip the docker steps (or if you don't have docker installed/running), add `-DskipDocker=true`
     
-    - enable keycloak as authentication service by passing `-Dkeycloak.auth.url=[KEYCLOAK_AUTH]` `-Dkeycloak.client.id=[KEYCLOAK_CLIENT_ID]` `-Dkeycloak.client.secret=[KEYCLOAK_CLIENT_SECRET]`
+    Here's a full example:
     
-        replace `KEYCLOAK_AUTH` with your Keycloak endpoint (tipically something like `http://quickstart-kc-quickstart.apps.rd.entando.org/auth`)
-        
-        replace `KEYCLOAK_CLIENT_ID` with your desired client id (tipically `quickstart-server`)
-        
-        replace `KEYCLOAK_CLIENT_SECRET` with your desired client's secret. To find the secret take a look at [How to find your client secret](#how-to-find-your-client-secret)
+        mvn clean package jetty:run-war -Pjetty-local -Pderby -Pkeycloak -Dspring.profiles.active=swagger-Djetty.port=8085 -Dorg.slf4j.simpleLogger.log.org.eclipse.jetty.annotations.AnnotationParser=error        -Dkeycloak.auth.url=http://my-keycloak-host/auth -Dkeycloak.client.id=quickstart-server -Dkeycloak.client.secret=my-client-secret -DskipDocker=true
+
+3.  Wait for the application to start.
+
+        [INFO] Started ServerConnector@1355c8be{HTTP/1.1, (http/1.1)}{0.0.0.0:8085}
+        [INFO] Started @66257ms
+        [INFO] Started Jetty Server
+
+4. Navigate to the Swagger UI in a browser at `/entando-de-app/api/swagger-ui.html`
+
+        http://localhost:[your port]/entando-de-app/api/swagger-ui.html
     
-    Now you can launch the command: 
-    
-         mvn clean package jetty:run-war -Pjetty-local -Pderby -Dspring.profiles.active=swagger -Djetty.port=8085 -Dorg.slf4j.simpleLogger.log.org.eclipse.jetty.annotations.AnnotationParser=error
-            -Dkeycloak.auth.url=http://quickstart-kc-quickstart.apps.rd.entando.org/auth -Dkeycloak.client.id=quickstart-server -Dkeycloak.client.secret=123412341-1234-1234-1234-123412341234
-
-* Note: If you don't have docker installed or running add `-DskipDocker=true` to the command above
-
-3.  Wait for the app to start.
-
-4.  Once started, navigate to the swagger ui in a browser.
-
-    http://localhost:[your port]/entando-de-app/api/swagger-ui.html
-    
-### Configure Keycloak
-
-Configure your Kecycloak client in order to support Swagger UI.
-
-1. login into your Keycloak instance
-
-2. access the Administration console
-
-3. click on *Clients* on the left bar and select your desired client (e.g. `quickstart-server`)
-
-4. in the *Settings* tab, fill the `Valid Redirect URIs` field with a valid value. It should be something like `http://localhost:[your port]/entando-de-app/*`, or simply `*`
-
-5. in the *Settings* tab, fill the `Web Origins` field with a valid value. It should be something like `http://localhost:[your port]`, or simply `*`
-
-
-## Setup in the quickstart environment
-
-Entando comes with Swagger UI enabled out of the box, it's reachable at `http://[your-entando-app-hostname]/entando-de-app/api/swagger-ui.html`, so for example at:
-
-    http://quickstart-flex.apps.rd.entando.org/entando-de-app/api/swagger-ui.html
-
-
-All you have to do is to [find your credentials](#how-to-find-your-client-secret) (client id and client secret) and start using Swagger UI.
-
-
-## How to find your client secret
-
-1. login into your keycloak instance
-
-2. access the Administration console
-
-3. click on *Clients* on the left bar and select your desired client (e.g. `quickstart-server`)
-
-4. click on the *Credentials* tab and get the secret 
 
 ## APIs Overview
 
 The Entando core exposes REST APIs for every action that can be taken in
-the App Builder and Admin Console environments. For example, you can use
-these apis to create pages, create page templates or to add widgets to
+the App Builder environment. For example, you can use
+these APIs to create pages, create page templates or to add widgets to
 pages. The APIs can be used to support automation, testing, or
 integrations with external systems.
 
@@ -105,22 +91,19 @@ response and varies according to each API.
 
 ### Models
 
-All of the model classes returned by the Entando core are annotated so
-that the model definition is included in the swagger documentation. At
-the bottom of the swagger page all of the model classes returned by the
-API endpoints can be found.
+All of the model classes returned by the Entando core are annotated so that the model definition is included in the Swagger documentation. At the bottom of the Swagger page all of the model classes returned by the API endpoints can be found.
 
-## Tutorial:
+## Tutorial
 
-1. access your application Swagger UI as discussed above
+1. Access your application Swagger UI as discussed above
 
-2. click on the `Authorize` button in the upper right corner
+2. Click on the `Authorize` button in the upper right corner
 
-3. enter client id and client secret in the open window and click `Authorize`
+3. Enter the client id and client secret in the open window and click `Authorize`
 
-4. if you are redirected to the Entando login page, log in with your credentials (default are `admin`/`adminadmin`)
+4. If you are redirected to the Entando login page, log in with your credentials (default are `admin`/`adminadmin`)
 
-5. you will be redirected to the Swagger UI page, now authenticated
+5. You will be redirected to the Swagger UI page, now authenticated
 
 6. Use the **Try it out** button on the APIs
 
@@ -130,4 +113,4 @@ API endpoints can be found.
 
     -   Select **Try it out**
 
-    -   Look at the results in the window
+    -   Look at the results in the window. You should see a Server response with Code 200 and full response body.

--- a/vuepress/docs/next/docs/reference/entando-apis.md
+++ b/vuepress/docs/next/docs/reference/entando-apis.md
@@ -4,24 +4,42 @@ sidebarDepth: 0
 
 # Accessing Entando APIs
 
-## Prerequisites
+## Overview
+
+Following the [quickstart guide](../getting-started/quick-reference.md), Entando comes with Swagger UI enabled out of the box.
+If you want to use Swagger UI in the local environment, proceed in the reading, otherwise you can directly go to step [Setup in the quickstart environment](#setup-in-the-quickstart-environment).
+
+## Setup in local environment
+
+### Prerequisites
 
 -   Java 8
 
 -   maven
 
-## Setup
+### Setup
 
 1.  Clone the Entando reference app if you don’t already have it.
 
         git clone https://github.com/entando-k8s/entando-de-app
 
-2.  Start the app for local execution and enable the swagger profile by
-    passing `-Dspring.profiles.active=swagger` to the jetty command. Set
-    the value of `-Djetty.port` to something available on your machine
-    e.g. 8085.
-
+2.  Start the app for local execution and 
+    
+    - enable the swagger profile by passing `-Dspring.profiles.active=swagger` to the jetty command. Set
+    the value of `-Djetty.port` to something available on your machine e.g. 8085.
+    
+    - enable keycloak as authentication service by passing `-Dkeycloak.auth.url=[KEYCLOAK_AUTH]` `-Dkeycloak.client.id=[KEYCLOAK_CLIENT_ID]` `-Dkeycloak.client.secret=[KEYCLOAK_CLIENT_SECRET]`
+    
+        replace `KEYCLOAK_AUTH` with your Keycloak endpoint (tipically something like `http://quickstart-kc-quickstart.apps.rd.entando.org/auth`)
+        
+        replace `KEYCLOAK_CLIENT_ID` with your desired client id (tipically `quickstart-server`)
+        
+        replace `KEYCLOAK_CLIENT_SECRET` with your desired client's secret. To find the secret take a look at [How to find your client secret](#how-to-find-your-client-secret)
+    
+    Now you can launch the command: 
+    
          mvn clean package jetty:run-war -Pjetty-local -Pderby -Dspring.profiles.active=swagger -Djetty.port=8085 -Dorg.slf4j.simpleLogger.log.org.eclipse.jetty.annotations.AnnotationParser=error
+            -Dkeycloak.auth.url=http://quickstart-kc-quickstart.apps.rd.entando.org/auth -Dkeycloak.client.id=quickstart-server -Dkeycloak.client.secret=123412341-1234-1234-1234-123412341234
 
 * Note: If you don't have docker installed or running add `-DskipDocker=true` to the command above
 
@@ -29,11 +47,43 @@ sidebarDepth: 0
 
 4.  Once started, navigate to the swagger ui in a browser.
 
-<!-- -->
-
     http://localhost:[your port]/entando-de-app/api/swagger-ui.html
+    
+### Configure Keycloak
 
-## Overview
+Configure your Kecycloak client in order to support Swagger UI.
+
+1. login into your Keycloak instance
+
+2. access the Administration console
+
+3. click on *Clients* on the left bar and select your desired client (e.g. `quickstart-server`)
+
+4. in the *Settings* tab, fill the `Valid Redirect URIs` field with a valid value. It should be something like `http://localhost:[your port]/entando-de-app/*`, or simply `*`
+
+5. in the *Settings* tab, fill the `Web Origins` field with a valid value. It should be something like `http://localhost:[your port]`, or simply `*`
+
+
+## Setup in the quickstart environment
+
+Entando comes with Swagger UI enabled out of the box, it's reachable at `http://[your-entando-app-hostname]/entando-de-app/api/swagger-ui.html`, so for example at:
+
+    http://quickstart-flex.apps.rd.entando.org/entando-de-app/api/swagger-ui.html
+
+
+All you have to do is to [find your credentials](#how-to-find-your-client-secret) (client id and client secret) and start using Swagger UI.
+
+## How to find your client secret
+
+1. login into your keycloak instance
+
+2. access the Administration console
+
+3. click on *Clients* on the left bar and select your desired client (e.g. `quickstart-server`)
+
+4. click on the *Credentials* tab and get the secret 
+
+## APIs Overview
 
 The Entando core exposes REST APIs for every action that can be taken in
 the App Builder and Admin Console environments. For example, you can use
@@ -61,45 +111,17 @@ API endpoints can be found.
 
 ## Tutorial:
 
-1.  Stop the Entando instance if it is running.
+1. access your application Swagger UI as discussed above
 
-2.  In the project open `src/main/conf/systemParams.properties`.
+2. click on the `Authorize` button in the upper right corner
 
-3.  Change the value of this property to reflect the port you are using
-    to run the app.
+3. enter client id and client secret in the open window and click `Authorize`
 
-    -   applicationBaseURL
+4. if you are redirected to the Entando login page, log in with your credentials (default are `admin`/`adminadmin`)
 
-    -   For example if running on 8085 you would have
-        `applicationBaseURL=http://localhost:8085/${entando.engine.web.context}/`
+5. you will be redirected to the Swagger UI page, now authenticated
 
-4.  Login to the admin console at ```http://localhost:8085/entando-de-app/do/login```
-
-5.  Once logged in go to `Administration - API Management - Consumers.`
-
-6.  Select the kebab button on the row labeled swagger.
-
-7.  On that screen enable the button for `client_credentials`.
-
-8.  On that screen enter `swagger` as the value for the secret.
-
-9.  Click `Save`
-
-10. Return to the Swagger UI, e.g. `http://localhost:8085/entando-de-app/api/swagger-ui.html`
-
-11. Click `Authorize`
-
-12. Enter
-
-    -   `user: admin`
-
-    -   `password: adminadmin`
-
-    -   `client: swagger`
-
-    -   `client_secret: swagger`
-
-13. Use the **Try it out** button on the APIs
+6. Use the **Try it out** button on the APIs
 
     -   Scroll to `widget-controller`
 
@@ -108,3 +130,6 @@ API endpoints can be found.
     -   Select **Try it out**
 
     -   Look at the results in the window
+
+### Troubleshooting
+

--- a/vuepress/docs/next/tutorials/backend-developers/run-local.md
+++ b/vuepress/docs/next/tutorials/backend-developers/run-local.md
@@ -2,7 +2,7 @@
 
 This tutorial will take you through running an Entando microservice and micro frontend in a local development environment. If you haven't generated your Entando Plugin yet start with the [Generate Microservice and Micro Frontend](./generate-microservices-and-micro-frontends.md) tutorial and then run these steps.
 
-All of the steps below assume you are in the directory where you generated your Entando Pluing
+All of the steps below assume you are in the directory where you generated your Entando Plugin
 
 ## Start Keycloak using docker-compose
 

--- a/vuepress/docs/next/tutorials/devops/local-tips-and-tricks.md
+++ b/vuepress/docs/next/tutorials/devops/local-tips-and-tricks.md
@@ -134,6 +134,9 @@ network:
 11. Verify connectivity via `ping 192.168.99.1` from the VM. You should get a response rather than a timeout.
 
 12. (Optional) Run a python server to verify you can access the VM from the host at `http://192.168.99.1:8000.` It may take a minute or so before the server is ready.
+```
+python3 -m http.server 8000
+```
 
 13. You should now be able to install Entando using the static IP. If your Entando installation stalled during startup and was previously configured using the static IP, it should continue starting up as soon as the external address is functional again. 
 

--- a/vuepress/docs/v6.2/tutorials/backend-developers/run-local.md
+++ b/vuepress/docs/v6.2/tutorials/backend-developers/run-local.md
@@ -2,7 +2,7 @@
 
 This tutorial will take you through running an Entando microservice and micro frontend in a local development environment. If you haven't generated your Entando Plugin yet start with the [Generate Microservice and Micro Frontend](./generate-microservices-and-micro-frontends.md) tutorial and then run these steps.
 
-All of the steps below assume you are in the directory where you generated your Entando Pluing
+All of the steps below assume you are in the directory where you generated your Entando Plugin
 
 ## Start Keycloak using docker-compose
 

--- a/vuepress/docs/v6.2/tutorials/devops/local-tips-and-tricks.md
+++ b/vuepress/docs/v6.2/tutorials/devops/local-tips-and-tricks.md
@@ -134,6 +134,9 @@ network:
 11. Verify connectivity via `ping 192.168.99.1` from the VM. You should get a response rather than a timeout.
 
 12. (Optional) Run a python server to verify you can access the VM from the host at `http://192.168.99.1:8000.` It may take a minute or so before the server is ready.
+```
+python3 -m http.server 8000
+```
 
 13. You should now be able to install Entando using the static IP. If your Entando installation stalled during startup and was previously configured using the static IP, it should continue starting up as soon as the external address is functional again. 
 


### PR DESCRIPTION
Updated documentation about Swagger UI.
I'm wondering if we should add any line or link about keycloak permissions configuration