### PR TITLE
Add "add" and init "commit" phase in documentation when init a new repository.

### DIFF
--- a/vuepress/docs/next/tutorials/backend-developers/build-and-deploy.md
+++ b/vuepress/docs/next/tutorials/backend-developers/build-and-deploy.md
@@ -65,6 +65,8 @@ f1b5933fe4b5: Pushed
 echo bundle >> .gitignore
 cd bundle/
 git init
+git add .
+git commit -m "Init Git repository"
 git remote add origin https://your/remote/repository.git
 git push -u origin master
 

--- a/vuepress/docs/next/tutorials/ecr/tutorials/create-ecr-bundle-from-git.md
+++ b/vuepress/docs/next/tutorials/ecr/tutorials/create-ecr-bundle-from-git.md
@@ -66,8 +66,10 @@ Finally, add a reference to this widget in the bundle `descriptor.yaml` file.
 From the bundle root, run
 
     git init
+    git add .
+    git commit -m "Init Git repository"
 
-This will initialize an empty Git repository.
+This will initialize an empty Git repository and commit files.
 
 Add remote repository as origin and push the bundle.
 

--- a/vuepress/docs/v6.2/tutorials/backend-developers/build-and-deploy.md
+++ b/vuepress/docs/v6.2/tutorials/backend-developers/build-and-deploy.md
@@ -65,6 +65,8 @@ f1b5933fe4b5: Pushed
 echo bundle >> .gitignore
 cd bundle/
 git init
+git add .
+git commit -m "Init Git repository"
 git remote add origin https://your/remote/repository.git
 git push -u origin master
 

--- a/vuepress/docs/v6.2/tutorials/ecr/tutorials/create-ecr-bundle-from-git.md
+++ b/vuepress/docs/v6.2/tutorials/ecr/tutorials/create-ecr-bundle-from-git.md
@@ -66,8 +66,10 @@ Finally, add a reference to this widget in the bundle `descriptor.yaml` file.
 From the bundle root, run
 
     git init
+    git add .
+    git commit -m "Init Git repository"
 
-This will initialize an empty Git repository.
+This will initialize an empty Git repository and commit files.
 
 Add remote repository as origin and push the bundle.
 


### PR DESCRIPTION
Init a new repository without content (or without added content) raise an error from Git (sorry in french on my environment).
> error: impossible de pousser des références vers 'github.com:avdev4j/testbug.git'

We should follow the Git  worklow when init a new repo. 

> echo "# testbug" >> README.md
> git init
> git add README.md
> git commit -m "first commit"
> git branch -M main
> git remote add origin git@github.com:avdev4j/testbug.git
> git push -u origin main

Those commands are displayed when you create an empty repository.