### PR TITLE
ENDOC-19 Add full text search

### DIFF
--- a/vuepress/docs/.vuepress/config.js
+++ b/vuepress/docs/.vuepress/config.js
@@ -36,6 +36,10 @@ module.exports = {
         align: 'top',
         selector: 'div[class*="language-"] pre'
     },
+    // Replaced default search with full-text FlexSearch https://github.com/nextapps-de/flexsearch
+    'flexsearch', {
+      searchResultLength: 30
+    }
   ],
   themeConfig: {
     logo: '/theme/logo.svg',

--- a/vuepress/docs/.vuepress/styles/index.styl
+++ b/vuepress/docs/.vuepress/styles/index.styl
@@ -76,6 +76,10 @@ body {
   border-radius: 0;
 }
 
+.links .search-box .suggestions {
+  font-size: 1.1rem;
+}
+
 .theme-container .sidebar {
   background: #F3F4F8;
 }

--- a/vuepress/package.json
+++ b/vuepress/package.json
@@ -28,6 +28,7 @@
     "vue-template-compiler": "^2.6.12",
     "vuepress": "^1.7.1",
     "vuepress-plugin-check-md": "^0.0.2",
+    "vuepress-plugin-flexsearch": "^0.1.0",
     "vuepress-plugin-medium-zoom": "^1.1.9",
     "vuepress-plugin-redirect-frontmatter": "^1.0.0"
   },


### PR DESCRIPTION
This enables full text search on the site. It's enabled in staging https://entando.github.io/entando-docs/ and all of the content on the pages is now indexed whereas before it was just page and section titles. Phrase searches also work much better now.