### PR TITLE
ENDOC-94 Rework version navigation to improve usability

### DIFF
--- a/vuepress/docs/.vuepress/components/EntandoVersionLinks.vue
+++ b/vuepress/docs/.vuepress/components/EntandoVersionLinks.vue
@@ -1,0 +1,118 @@
+<!-- This component is modeled on theme/components/NavLinks.vue but using custom Entando version config -->
+<template>
+  <div class="entando-version-links">
+    <span class="version-wrapper">{{version}}</span>
+    <div
+        v-for="item in links"
+        :key="item.link"
+        class="nav-item"
+    >
+      <DropdownLink
+          v-if="item.type === 'links'"
+          :item="item"
+      />
+      <NavLink
+          v-else
+          :item="item"
+      />
+    </div>
+  </div>
+</template>
+<script>
+import DropdownLink from '@theme/components/DropdownLink.vue'
+import NavLink from '@theme/components/NavLink.vue'
+
+export default {
+  name: 'EntandoVersionLinks',
+
+  components: {
+    NavLink,
+    DropdownLink
+  },
+
+  computed: {
+    isDocs () {
+      const currentPath = this.$page.path
+      //Check for tutorials so the default is docs
+      return !currentPath.includes("/tutorials")
+    },
+
+    version () {
+      const entando = this.$site.themeConfig.entando
+
+      const currentPath = this.$page.path
+      if (!currentPath.includes(entando.version)) {
+        //Relies on the nav consisting of a parent item with a child set of items, following the NavLinks design
+        const item = this.nav[0].items.find(item => {
+          return currentPath.startsWith(item.link)
+        })
+        entando.version = item ? item.text : "NEXT"
+      }
+      return entando.version
+    },
+
+    nav () {
+      const entando = this.$site.themeConfig.entando
+      return this.isDocs ? entando.docs : entando.tutorials
+    },
+
+    links () {
+      return (this.nav || []).map(link => {
+        return Object.assign(resolveNavLinkItem(link), {
+          items: (link.items || []).map(resolveNavLinkItem)
+        })
+      })
+    },
+  }
+}
+
+//Lifted from @theme/util.js which can't be loaded directly in a child theme.
+function resolveNavLinkItem (linkItem) {
+  return Object.assign(linkItem, {
+    type: linkItem.items && linkItem.items.length ? 'links' : 'link'
+  })
+}
+</script>
+
+<style lang="stylus">
+.entando-version-links
+  color grey !important
+  font-style italic
+  font-weight 500
+  padding-left: 1.5rem
+  padding-top: 1.0rem
+  a
+    line-height 1.4rem
+    color inherit
+    &:hover, &.router-link-active
+      color $accentColor
+  .nav-item
+    position relative
+    display inline-block
+    line-height 2rem
+    &:first-child
+      margin-left 0
+  .version-wrapper
+    font-size 0.9rem
+    font-variant small-caps
+  .dropdown-wrapper .dropdown-title span
+    color grey
+    font-style italic
+    font-variant small-caps
+
+
+  @media (max-width: $MQMobile)
+    .nav-links
+      .nav-item, .repo-link
+        margin-left 0
+
+  @media (min-width: $MQMobile)
+    .nav-links a
+      &:hover, &.router-link-active
+        color $textColor
+    .nav-item > a:not(.external)
+      &:hover, &.router-link-active
+        margin-bottom -2px
+        border-bottom 2px solid lighten($accentColor, 8%)
+
+</style>

--- a/vuepress/docs/.vuepress/config.js
+++ b/vuepress/docs/.vuepress/config.js
@@ -2,6 +2,7 @@ const next  = require('./next.js');
 const V63  = require('./v63.js');
 const V62  = require('./v62.js');
 const V61  = require('./v61.js');
+const navLinks = require('./navLinks.js');
 
 module.exports = {
   title: 'Entando Developers',
@@ -49,17 +50,6 @@ module.exports = {
     editLinkText: 'Edit this page on GitHub',
     lastUpdated: 'Last Updated',
     nav: [
-      {
-        text: 'Versions',
-        items: [
-          { text: 'Next', link: '/next/docs/' },
-          { text: '6.3', link: '/v6.3/docs/' },
-          { text: '6.2', link: '/v6.2/docs/' },
-          { text: '6.1', link: '/v6.1/docs/' },
-          //  Open new window to avoid SSR issues when moving from Vue to straight html
-          { text: '5.3', link: '/old-version/old-version.html', target:'_blank'},
-        ]
-      },
       { text: 'Docs', link: 'javascript:Entando.versionedLink("/docs");', target: '_self' },
       { text: 'Tutorials', link: 'javascript:Entando.versionedLink("/tutorials");', target: '_self' },
       { text: 'Forum', link: 'https://forum.entando.org' },
@@ -78,6 +68,13 @@ module.exports = {
       '/v6.2/tutorials/': V62.tutorialsSidebar('/v6.2/tutorials/'),
       '/v6.1/docs/': V61.docsSidebar('/v6.1/docs/'),
       '/v6.1/tutorials/': V61.tutorialsSidebar('/v6.1/tutorials/'),
-    }
+    },
+    // Custom theme config
+    entando: {
+      section: "Docs",
+      version: "6.3",
+      docs: navLinks.links('Docs', '/docs/'),
+      tutorials: navLinks.links('Tutorials', '/tutorials/')
+    },
   }
 }

--- a/vuepress/docs/.vuepress/navLinks.js
+++ b/vuepress/docs/.vuepress/navLinks.js
@@ -1,0 +1,17 @@
+module.exports = {
+    links: function (section, path) {
+        return [
+            {
+                text: section,
+                items: [
+                    { text: 'NEXT', link: '/next' + path },
+                    { text: '6.3', link: '/v6.3' + path },
+                    { text: '6.2', link: '/v6.2' + path },
+                    { text: '6.1', link: '/v6.1' + path },
+                    //  Open new window to avoid SSR issues when moving from Vue to straight html
+                    { text: '5.3', link: '/old-version/old-version.html', target:'_blank'},
+                ]
+            }
+        ]
+    }
+}

--- a/vuepress/docs/.vuepress/plugins/entando-nav-version/enhanceAppFile.js
+++ b/vuepress/docs/.vuepress/plugins/entando-nav-version/enhanceAppFile.js
@@ -5,7 +5,7 @@ export default ({ router, isServer }) => {
     window.Entando = window.Entando || {};
 
     window.Entando.versionedLink = async function(path) {
-        console.debug("Nav to path: " + path);
+        // console.debug("Nav to path: " + path);
         var pathname = window.location.pathname;
         var versionPos = pathname.indexOf("/v6");
         var nextPos = pathname.indexOf("/next/");
@@ -18,7 +18,7 @@ export default ({ router, isServer }) => {
         var pos = pathname.indexOf("/", start + 1);
         var activeVersion = pathname.substring(start, pos);
         var target = activeVersion + path;
-        console.debug("Target for router: " + target);
+        // console.debug("Target for router: " + target);
         try {
             await router.push(target);
         } catch (err) {

--- a/vuepress/docs/.vuepress/styles/index.styl
+++ b/vuepress/docs/.vuepress/styles/index.styl
@@ -42,13 +42,6 @@ body {
   font-weight: 500 !important;
 }
 
-.dropdown-title {
-  color: white !important;
-  font-size: 20px !important;
-  font-variant: small-caps !important;
-  font-weight: 500 !important;
-}
-
 @media (max-width: 719px) {
   .dropdown-wrapper .dropdown-title {
     color: #000 !important;
@@ -82,6 +75,10 @@ body {
 
 .theme-container .sidebar {
   background: #F3F4F8;
+}
+
+.theme-container .sidebar > .sidebar-links {
+  padding-top: 0;
 }
 
 .sidebar-group.is-sub-group > .sidebar-heading:not(.clickable) {

--- a/vuepress/docs/.vuepress/theme/layouts/Layout.vue
+++ b/vuepress/docs/.vuepress/theme/layouts/Layout.vue
@@ -1,9 +1,12 @@
-<!-- Override the default Layout so we can add the cookie banner and tracking to all content pages using the theme.
-Similar code exists in components/SpecialLayout.vue -->
+<!-- Override and extend the default theme Layout -->
 <template>
   <div>
-    <Layout/>
-    <tracking/>
+    <Layout>
+      <template #sidebar-top>
+        <EntandoVersionLinks/>
+      </template>
+    </Layout>
+    <Tracking/>
   </div>
 </template>
 <script>


### PR DESCRIPTION
This moves the navigation from the top nav bar over to the side bar, displays the current version more clearly, and makes it easier to switch versions. It still only links to the root page for each section (docs or tutorials), just like before, but this is closer to what other open source projects do. My hands were tied a bit by Vuepress in terms of styling but open to suggestions on improvements.

This is deployed to my github pages site now https://nshaw.github.io/v6.2/docs/ and here's a screenshot.
![Entando-Platform-Entando-Developers](https://user-images.githubusercontent.com/645546/103822623-7a996600-503e-11eb-95db-3c0d32a5e94a.png)
