### PR TITLE
Endoc 182 minor edits

### DIFF
--- a/vuepress/deploy-staging.sh
+++ b/vuepress/deploy-staging.sh
@@ -18,7 +18,6 @@ npm run docs:build
 git restore docs/.vuepress/config.js
 git restore docs/.vuepress/components/css/main.css
 git restore docs/.vuepress/components/SpecialLayout.vue
-git restore docs/.vuepress/components/SpecialLayout62.vue
 git restore docs/.vuepress/styles/index.styl
 
 # navigate into the build output directory

--- a/vuepress/deploy-staging.sh
+++ b/vuepress/deploy-staging.sh
@@ -7,7 +7,10 @@ set -e
 # referenced by custom layouts which don't use that setting.
 sed -i "s/base: '\/'/base: '\/entando-docs\/'/g" docs/.vuepress/config.js
 sed -i "s/'\//'\/entando-docs\//g" docs/.vuepress/components/css/main.css
+## modify href="
 sed -i "s/=\"\//=\"\/entando-docs\//g" docs/.vuepress/components/SpecialLayout.vue
+## modify activePath: "/
+sed -i "s/: \"\//: \"\/entando-docs\//g" docs/.vuepress/components/SpecialLayout.vue
 sed -i "s/'\/theme/'\/entando-docs\/theme/g" docs/.vuepress/components/SpecialLayout.vue
 sed -i "s/'\//'\/entando-docs\//g" docs/.vuepress/styles/index.styl
 

--- a/vuepress/docs/.vuepress/components/EntandoCodeCopy.vue
+++ b/vuepress/docs/.vuepress/components/EntandoCodeCopy.vue
@@ -1,0 +1,144 @@
+<!-- Component forked from https://github.com/znicholasbrown/vuepress-plugin-code-copy. Once we move the
+ special layouts into the theme we can drop this code in favor of the actual theme plugin already in use for
+ themed pages. This component was modified slightly to set the svg to 1remx1rem and to trim the code -->
+<template>
+    <div class="code-copy">
+        <!-- CUSTOM: width/height -->
+        <svg
+            @click="copyToClipboard"
+            xmlns="http://www.w3.org/2000/svg"
+            width="1rem"
+            height="1rem"
+            viewBox="0 0 24 24"
+            :class="iconClass"
+            :style="alignStyle"
+        >
+            <path fill="none" d="M0 0h24v24H0z" />
+            <path
+                :fill="options.color"
+                d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+            />
+        </svg>
+        <span :class="success ? 'success' : ''" :style="alignStyle">
+            {{ options.successText }}
+        </span>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        parent: Object,
+        code: String,
+        options: {
+            align: String,
+            color: String,
+            backgroundTransition: Boolean,
+            backgroundColor: String,
+            successText: String,
+            staticIcon: Boolean
+        }
+    },
+    data() {
+        return {
+            success: false,
+            originalBackground: null,
+            originalTransition: null
+        }
+    },
+    computed: {
+        alignStyle() {
+            let style = {}
+            style[this.options.align] = '7.5px'
+            return style
+        },
+        iconClass() {
+            return this.options.staticIcon ? '' : 'hover'
+        }
+    },
+    mounted() {
+        this.originalTransition = this.parent.style.transition
+        this.originalBackground = this.parent.style.background
+    },
+    beforeDestroy() {
+        this.parent.style.transition = this.originalTransition
+        this.parent.style.background = this.originalBackground
+    },
+    methods: {
+        // From: https://stackoverflow.com/a/5624139
+        hexToRgb(hex) {
+            let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+            return result
+                ? {
+                      r: parseInt(result[1], 16),
+                      g: parseInt(result[2], 16),
+                      b: parseInt(result[3], 16)
+                  }
+                : null
+        },
+        copyToClipboard(el) {
+            // trim to remove leading and trailing space
+            if (navigator.clipboard) {
+              navigator.clipboard.writeText(this.code.trim()).then(
+                    () => {
+                        this.setSuccessTransitions()
+                    },
+                    () => {}
+                )
+            } else {
+                let copyelement = document.createElement('textarea')
+                document.body.appendChild(copyelement)
+                copyelement.value = this.code
+                copyelement.select()
+                document.execCommand('Copy')
+                copyelement.remove()
+                this.setSuccessTransitions()
+            }
+        },
+        setSuccessTransitions() {
+            clearTimeout(this.successTimeout)
+            if (this.options.backgroundTransition) {
+                this.parent.style.transition = 'background 350ms'
+                let color = this.hexToRgb(this.options.backgroundColor)
+                this.parent.style.background = `rgba(${color.r}, ${color.g}, ${color.b}, 0.1)`
+            }
+            this.success = true
+            this.successTimeout = setTimeout(() => {
+                if (this.options.backgroundTransition) {
+                    this.parent.style.background = this.originalBackground
+                    this.parent.style.transition = this.originalTransition
+                }
+                this.success = false
+            }, 500)
+        }
+    }
+}
+</script>
+
+<!-- CUSTOM: Tweak styles to match landing pages-->
+<style lang="stylus">
+.code-copy
+  svg
+    position: absolute
+    right: 7.5px
+    opacity: 0.75
+    cursor: pointer
+
+  svg.hover
+    opacity: 0
+
+  svg:hover
+    opacity: 1 !important
+
+  span
+    position: absolute
+    font-size: 0.85rem
+    line-height: 0.425rem
+    right: 50px
+    opacity: 0
+    transition: opacity 500ms
+
+  .success
+    opacity: 1 !important
+    color: #002F87
+</style>

--- a/vuepress/docs/.vuepress/components/SpecialLayout.vue
+++ b/vuepress/docs/.vuepress/components/SpecialLayout.vue
@@ -134,7 +134,7 @@
             <div style="display:none">
               <p>Download the Entando Custom Resource Definitions (CRDs)</p>
               <div class="instruction">
-                curl -L -C - <span class="hide-xl">\<br></span>https://raw.githubusercontent.com/entando/entando-releases/{{activeVersionTag}}/dist/qs/custom-resources.tar.gz <span class="hide-xl">\<br></span>| tar -xz
+                curl -L -C - https://raw.githubusercontent.com/entando/entando-releases/{{activeVersionTag}}/dist/qs/custom-resources.tar.gz | tar -xz
               </div>
               <p>Install the Entando CRDs</p>
               <div class="instruction">
@@ -146,7 +146,7 @@
               </div>
               <p>Download Helm chart. Note: if you have OpenShift 3.11, use entando-okd3.yaml for the remaining steps.</p>
               <div class="instruction">
-                curl -L -C - -O <span>\<br></span>https://raw.githubusercontent.com/entando/entando-releases/{{activeVersionTag}}/dist/qs/entando-okd4.yaml
+                curl -L -C - -O https://raw.githubusercontent.com/entando/entando-releases/{{activeVersionTag}}/dist/qs/entando-okd4.yaml
               </div>
               <p>Set an environment variable using the IP address from Step 1. For a managed cluster address, you can remove .nip.io from the value.</p>
               <div class="instruction">
@@ -250,11 +250,14 @@
       </div>
 
     </div>
-    <tracking/>
+    <Tracking/>
   </div>
 </template>
 
 <script>
+import EntandoCodeCopy from './EntandoCodeCopy'
+import Vue from 'vue'
+
 export default {
   data: function() {
     return {
@@ -266,7 +269,35 @@ export default {
     }
   },
   props: ['jhipster','openshift'],
+  updated () {
+    this.update()
+  },
   methods: {
+    //This code is copied from CodeCopy plugin and can be removed if/when this layout merges into the theme
+    update() {
+      setTimeout(() => {
+        document.querySelectorAll('.instruction').forEach(el => {
+          if (el.classList.contains('code-copy-added')) return
+          let ComponentClass = Vue.extend(EntandoCodeCopy)
+          let instance = new ComponentClass()
+
+          let options = {
+            align: 'top',
+            color: '#27b1ff',
+            backgroundColor: '#0075b8',
+            backgroundTransition: true,
+            successText: 'Copied!',
+            staticIcon: true
+          }
+          instance.options = { ...options }
+          instance.code = el.innerText
+          instance.parent = el
+          instance.$mount()
+          el.classList.add('code-copy-added')
+          el.appendChild(instance.$el)
+        })
+      }, 100)
+    },
     path: function(path) {
       return this.activeVersionPath + path;
     },
@@ -339,7 +370,11 @@ export default {
   }
 }
 </script>
-
+<style>
+.code-copy-added:hover>.code-copy svg {
+  opacity: .75;
+}
+</style>
 <style>
   @import url('css/main.css');
 </style>

--- a/vuepress/docs/.vuepress/components/css/main.css
+++ b/vuepress/docs/.vuepress/components/css/main.css
@@ -401,6 +401,7 @@
   font-size: max(10px, 0.8125em);
   
   color: #002F87;
+  position: relative;
 }
 
 @media only screen and (min-width: 320px) and (max-width: 479px) {
@@ -410,18 +411,6 @@
     white-space: nowrap;
     max-width: calc(100% - 16px);
     box-sizing: border-box;
-  }
-}
-
-@media only screen and (min-width: 480px) {
-  #dev-entando .instruction span:not(.hide-xl) {
-    display: none;  
-  }
-}
-
-@media only screen and (min-width: 1280px) {
-  #dev-entando .instruction .hide-xl {
-    display: none;
   }
 }
 

--- a/vuepress/docs/next/docs/getting-started/README.md
+++ b/vuepress/docs/next/docs/getting-started/README.md
@@ -157,7 +157,7 @@ From your Ubuntu shell:
 1. Download custom resource definitions.
 
 ``` bash
-wget -c https://raw.githubusercontent.com/entando/entando-releases/v6.3.0/dist/qs/custom-resources.tar.gz -O - | tar -xz
+curl -L -C - https://raw.githubusercontent.com/entando/entando-releases/v6.3.0/dist/qs/custom-resources.tar.gz | tar -xz
 ```
 
 2. Create custom resources

--- a/vuepress/docs/v6.3/docs/getting-started/README.md
+++ b/vuepress/docs/v6.3/docs/getting-started/README.md
@@ -157,7 +157,7 @@ From your Ubuntu shell:
 1. Download custom resource definitions.
 
 ``` bash
-wget -c https://raw.githubusercontent.com/entando/entando-releases/v6.3.0/dist/qs/custom-resources.tar.gz -O - | tar -xz
+curl -L -C - https://raw.githubusercontent.com/entando/entando-releases/v6.3.0/dist/qs/custom-resources.tar.gz | tar -xz
 ```
 
 2. Create custom resources


### PR DESCRIPTION
Two tweaks here: 1) Add the code-copy button to the landing pages. Bit of forked code there since the landing pages don't use the theme so they can't use theme plugins. 2) Replace a couple more usages of wget in favor of curl.