### PR TITLE
Endoc 192 quickstart tips

### DIFF
--- a/vuepress/docs/.vuepress/components/SpecialLayout.vue
+++ b/vuepress/docs/.vuepress/components/SpecialLayout.vue
@@ -175,7 +175,7 @@
                 oc get ingress -n entando -o jsonpath='{.items[2].spec.rules[*].host}{.items[2].spec.rules[*].http.paths[2].path}{"\n"}'
               </div>
               <p>Login to the <span>Entando App Builder</span> with username:<span>admin</span>, password: <span>adminadmin</span></p>
-              <p>See the <a :href="path('/docs/')">Docs</a> and <a :href="path('/tutorials/')">Tutorials</a> to continue your journey with Entando.</p>
+              <p>Choose an action from the <a :href="path('/docs/getting-started/#next-steps')">Next Steps</a> list to continue your journey with Entando!</p>
             </div>
 
             <hr class="get-started-separator" />
@@ -239,8 +239,8 @@
               </div>
               <p>The progress of the install will be displayed on the console and can take 10 minutes or so depending on the time needed to download the Docker images.</p>
               <p>Once complete, the installer will give you the URL to access the <span>Entando App Builder</span>.</p>
-              <p>Login with username:<span>admin</span> and password: <span>adminadmin</span></p>
-              <p>See the <a :href="path('/docs/')">Docs</a> and <a :href="path('/tutorials/')">Tutorials</a> to continue your journey with Entando!</p>
+              <p>Login with username: <span>admin</span> and password: <span>adminadmin</span></p>
+              <p>Choose an action from the <a :href="path('/docs/getting-started/#next-steps')">Next Steps</a> list to continue your journey with Entando!</p>
             </div>
             <hr class="get-started-separator" />
 

--- a/vuepress/docs/.vuepress/next.js
+++ b/vuepress/docs/.vuepress/next.js
@@ -96,6 +96,10 @@ module.exports = {
                         title: 'Freemarker CMS Tags',
                         path: path + 'reference/freemarker-tags/freemarker-JACMS-tags.md'
                     },
+                    {
+                        title: 'Development Tips and Tricks',
+                        path: path  + 'reference/local-tips-and-tricks.md',
+                    }
                 ]
             },
             {
@@ -255,10 +259,6 @@ module.exports = {
                     {
                         title: 'Installation on Google Kubernetes Engine (GKE)',
                         path: path  + 'devops/installation/google-cloud-platform/',
-                    },
-                    {
-                        title: 'Local Tips and Tricks',
-                        path: path  + 'devops/local-tips-and-tricks.md',
                     },
                 ]
             },

--- a/vuepress/docs/.vuepress/v63.js
+++ b/vuepress/docs/.vuepress/v63.js
@@ -96,6 +96,10 @@ module.exports = {
                         title: 'Freemarker CMS Tags',
                         path: path + 'reference/freemarker-tags/freemarker-JACMS-tags.md'
                     },
+                    {
+                        title: 'Development Tips and Tricks',
+                        path: path  + 'reference/local-tips-and-tricks.md',
+                    },
                 ]
             },
             {
@@ -256,10 +260,6 @@ module.exports = {
                     {
                         title: 'Installation on Google Kubernetes Engine (GKE)',
                         path: path  + 'devops/installation/google-cloud-platform/',
-                    },
-                    {
-                        title: 'Local Tips and Tricks',
-                        path: path  + 'devops/local-tips-and-tricks.md',
                     },
                 ]
             },

--- a/vuepress/docs/next/docs/getting-started/README.md
+++ b/vuepress/docs/next/docs/getting-started/README.md
@@ -16,7 +16,7 @@ The following steps will launch an Ubuntu VM via Multipass, install Kubernetes, 
 ``` http request
 https://multipass.run/#install
 ```
-2. Install Entando via the [Entando CLI](../reference/entando-cli.md) 
+2. Install Entando in an Ubuntu VM via the [Entando CLI](../reference/entando-cli.md) 
 
 ```sh
 curl -sfL https://get.entando.org | bash
@@ -209,7 +209,7 @@ database connection.
 Entando sets up `Ingresses` in Kubernetes to access services from outside your server cluster.
 We'll use this to access Entando from a local browser. 
 
-If you run into network issues during startup or if you are using Windows for your local development instance, please see [the tips](../../tutorials/devops/local-tips-and-tricks.md#network-issues). Symptoms can include having Entando fail to completely start the first time or a working Entando installation may fail to restart later. 
+If you run into network issues during startup or if you are using Windows for your local development instance, please see [the tips](../reference/local-tips-and-tricks.md#network-issues). Symptoms can include having Entando fail to completely start the first time or a working Entando installation may fail to restart later. 
 :::
 
 To set up external access to your cluster, you'll need to replace the value of
@@ -401,8 +401,17 @@ We now have Entando up and running on Kubernetes in our local environment.
 :::
 
 ---
+## Next Steps
+Choose one of the following actions to continue your journey with Entando!
+ 
+* **Build Your First Application:** Use the [Welcome Wizard](./welcome-wizard.md) to build your first application via guided prompts. 
 
-Follow the steps in the [Welcome Wizard](./welcome-wizard.md) to build your first application or see the other [Docs](../) and [Tutorials](../../tutorials/) to continue your journey with Entando!
+* **Try a Tutorial:** Take advantage of the [Learning Paths](../../tutorials/#learning-paths) which organize a few of the most popular tutorials by user type.
 
---
+* **Dig Deeper into Entando Concepts:** Review the [Docs](../) sections to more deeply understand the Entando building blocks.
+
+* **Learn about the Quickstart Environment:** See the [Quickstart Tips](../reference/local-tips-and-tricks.md) for more information on how to manage your Getting Started or quickstart environment.  
+
+---
+
 

--- a/vuepress/docs/next/docs/reference/local-tips-and-tricks.md
+++ b/vuepress/docs/next/docs/reference/local-tips-and-tricks.md
@@ -1,15 +1,29 @@
 ---
 sidebarDepth: 2
+redirectFrom: /next/tutorials/devops/local-tips-and-tricks.html
 --- 
-# Local Development Tips and Tricks
-We've collected a list of tips and tricks for optimizing your local development environment. 
-We invite you to ask questions, collaborate with the community, and share your own favorite 
+# Development Tips and Tricks
+We've collected a list of tips and tricks for optimizing your local quickstart or [Getting Started](../../docs/getting-started/) development environment. We invite you to ask questions, collaborate with the community, and share your own favorite 
 practices over on the [Entando forum](https://forum.entando.org).
 
-## Kubernetes
-Per the [Getting Started](../../docs/getting-started/) guide, we've recommended using Multipass as a way to quickly spin up an Ubuntu VM to host a local Kubernetes cluster for test purposes. There are many times when a local environment is useful but most teams utilize a shared Kubernetes cluster managed by an operations team and installed either on premise or with a cloud provider for full integration testing, CI/CD, DevOps, etc. 
+## Quickstart Management
+Here are a few common questions about the quickstart environment which uses Multipass to launch an Ubuntu VM, install K3s Kubernetes into it, and then deploy Entando.
+ 
+### Multipass
+1. **How can I shell into a Multipass VM?** `multipass shell <VM-NAME>`. If you don't provide a VM-NAME, multipass will use the default name `primary` and even launch it for you if it doesn't exist. 
+1. **What do I need to do after restarting my laptop?** By default Multipass is installed as a service and will restart automatically. If Multipass isn't running, you'll need to first start the service, and then you can start your VM via `multipass start <VM-NAME>`. Kubernetes will start automatically along with any installed pods, including Entando. It can take a few minutes for all of the pods to start completely but you can use `sudo kubectl -n entando pods --watch` to observe the progress. 
+1. **How can I idle or pause my Entando instance?** You can use either `multipass stop <VM-NAME>` or `multipass suspend <VM-NAME>`, if you'd rather preserve the VM state. You can then use `multipass start <VM-NAME>` to start the VM. 
+1. **What else can Multipass do?** You can run `multipass help` or refer to the [Multipass docs](https://multipass.run/docs) for more information on Multipass.
 
-## Network issues
+### Entando in Kubernetes
+1. **How can I install a new copy of Entando into an existing VM?** The quickstart deploys Kubernetes resources into a dedicated namespace, `entando` by default. You can simply delete the namespace, `sudo kubectl delete namespace entando`, if you want to delete all of its resources. You can then re-create the namespace and re-install by applying the Helm template for your environment. Alternatively, you can use `ent quickstart --vm-reuse=true` but you'll need to set other `ent quickstart` options so check the `ent` help.
+1. **How can I shell into a running pod or view its logs?** You can use the standard Kubernetes commands, e.g. `sudo kubectl exec -it <POD-NAME> -c <CONTAINER-NAME -- bash` or `sudo kubectl logs <POD-NAME> <CONTAINER-NAME>`
+1. **What do I if Entando doesn't start completely?** The most common cause for this is a networking problem. See the [Network issues](#network-issues) section below for details. If all else fails reach out to the Entando team on Slack or in the Forums. 
+
+## Shared Servers
+We've recommended using Multipass as a way to quickly spin up an Ubuntu VM to host a local Kubernetes cluster for test purposes. There are many times when a local environment is useful but most teams utilize a shared Kubernetes cluster managed by an operations team and installed either on premise or with a cloud provider for full integration testing, CI/CD, DevOps, etc. 
+
+## Network Issues
 A local Entando 6.3 quickstart installation (e.g. what you'll get if you follow the [Getting Started](../../docs/getting-started/) guide) may use a set of local domain names to enable accessing Entando services. Your IP address will vary but may look something like this:
 ```
 quickstart-entando.192.168.99.1.nip.io
@@ -26,21 +40,23 @@ The base domain configured via the ENTANDO_DEFAULT_ROUTING_SUFFIX (e.g. in your 
  192.168.99.1 quickstart-entando.192.168.99.1.nip.io
 ```
 - If you add microservices to your installation, you may need to add additional mappings for the new ingresses.
-- See [this section below](#option-1-manually-update-your-hosts-file) for detailed steps on Windows.
+- See [this section below](#option-2-manually-update-your-hosts-file) for detailed steps on Windows.
 
 ### `The IP address changed after the initial install`
 - The workaround noted above (e.g. update your /etc/hosts file) can also be used here. Simply update the IP address in the first column to use the current IP of your virtual machine. 
 - On Windows this can happen simply because your laptop restarted. See [Windows Hyper-V IP Changes](#hyper-v-ip-changes) below. 
 
-## Windows development
-### Hyper-V IP changes
+## Windows Development
+### Hyper-V IP Changes
 **Q:** My Entando installation stops working when I restart Windows. How can I fix this?
 
-**A:** The basic issue is that Windows Hyper-V makes it difficult to set
-a static IP for a VM. (See this [forum post](https://techcommunity.microsoft.com/t5/windows-insider-program/hyper-v-default-switch-ip-address-range-change-ver-1809-build/m-p/261431) for details.) As discussed [above](#network-issues), Entando's ingress routes rely on an fixed IP address and will break if the IP address changes after initial installation. Here are a few options to solve this issue, short of modifying your router or network switch settings: 
+**A:** The basic issue is that Windows Hyper-V makes it difficult to set a static IP for a VM. (See this [forum post](https://techcommunity.microsoft.com/t5/windows-insider-program/hyper-v-default-switch-ip-address-range-change-ver-1809-build/m-p/261431) for details.) As discussed [above](#network-issues), Entando's ingress routes rely on an fixed IP address and will break if the IP address changes after initial installation. Here are a few options to solve this issue, short of modifying your router or network switch settings: 
 
-#### Option 1: Manually update your hosts file
-The simplest option to re-enable external access to your cluster is to update your hosts file after each Windows restart.
+#### Option 1: Single host routing
+The simplest way to deal with the peculiarities of Hyper-V IP assignments is to avoid it by using the Windows-specific mshome.net addresses. This allows you to access a VM by using an address like `<VM-NAME>.mshome.net`. If you set up your enviroment using the [Automatic Install](../getting-started/#automatic-install) instructions, then the ent CLI will select the single host option for you and the address will be `entando.mshome.net`. You can accomplish the same thing yourself using the `ent quickstart` script but see its `--help` for the current set of options.
+
+#### Option 2: Manually update your hosts file
+The next simplest option to re-enable external access to your cluster is to update your hosts file after each Windows restart.
  
 You need two pieces of information for this workaround and you'll need administrator access to do this.
 
@@ -69,7 +85,7 @@ primary                 Running           172.31.118.12   Ubuntu 18.04 LTS
 
 4. You should now be able to access your Entando URLs via the new IP. If your Entando installation stalled during startup, it should continue starting up as soon as the external address is functional again. 
 
-#### Option 2: Add a Windows route
+#### Option 3: Add a Windows route
 This option is a little more involved the first time but it means repairing your network settings can be done very easily later. In this case you'll pick a static IP, configure a Windows route to map it to the Hyper-V interface, and claim the IP in the Ubuntu VM via a netplan entry. 
 
  You'll need to run all of these steps before installing Entando the first time but then just steps #1 and #2 after subsequent Windows restarts. 
@@ -140,7 +156,7 @@ python3 -m http.server 8000
 
 13. You should now be able to install Entando using the static IP. If your Entando installation stalled during startup and was previously configured using the static IP, it should continue starting up as soon as the external address is functional again. 
 
-#### Option 3: Reinstall Entando
+#### Option 4: Reinstall Entando
 We're including this option because it works and requires no additional configuration. If you plan to regularly work with Entando we recommend developing against a centralized and shared Kubernetes instance rather than running a full stack locally. If you need a cluster locally we recommend using option 1 or 2.
 
 ### JHipster

--- a/vuepress/docs/next/tutorials/README.md
+++ b/vuepress/docs/next/tutorials/README.md
@@ -1,5 +1,5 @@
 ---
-sidebarDepth: 0
+sidebarDepth: 2
 ---
 ::: danger
 This documentation is for the version of Entando currently under development and is a work in progress. 
@@ -8,7 +8,6 @@ only be available by building from source.
 :::
 
 # Tutorials 
-## Overview
 
 ::: tip Entando simplifies the development of modern apps:
 
@@ -21,7 +20,8 @@ Entando supports full stack micro frontend and microservice architectures for co
 
 Use the navigation on the left to find step-by-step tutorials for common tasks or check out our learning paths below for a more structured approach.
 
-## Frontend Developers
+## Learning Paths
+### Frontend Developers
 
 <style>
 table th:first-of-type {
@@ -43,7 +43,7 @@ table th:nth-of-type(3) {
 | [Create and Manage Content](./cms/content-tutorial.md)| |
 
 
-## Backend Developers
+### Backend Developers
 
 | Basic | Intermediate | Advanced
 | :-: | :-: | :-:
@@ -51,7 +51,7 @@ table th:nth-of-type(3) {
 | [Generate Micro Frontends and Microservices Based on a Database Entity](./backend-developers/generate-microservices-and-micro-frontends.md) | [Export a Bundle from an Existing Application](./ecr/export-bundle-from-application.md) | 
 | [Run Micro Frontends and Microservices in your local env](./backend-developers/run-local.md) |Use JDL Studio to Create a Complex Database Entity (Coming Soon)  |
 
-## DevOps
+### DevOps
 
 | Basic | Intermediate | Advanced
 | :-: | :-: | :-:

--- a/vuepress/docs/next/tutorials/devops/installation/open-shift/openshift-install.md
+++ b/vuepress/docs/next/tutorials/devops/installation/open-shift/openshift-install.md
@@ -140,7 +140,7 @@ http://quickstart-entando.192.168.64.10.nip.io/app-builder/
 
 If you see errors when images are being retrieved (resulting in errors like ErrImagePull or ImagePullBackOff), you may want to start crc using ```crc start -n "8.8.8.8``` or configure the nameserver using ```crc config set nameserver 8.8.8.8``` before running ```crc start```. This will allow the cluster to perform DNS lookups via Google's public DNS server.
 
-If you're on Windows, you should also check out the notes [here](../../local-tips-and-tricks.md) since Minishift and CRC rely on Windows Hyper-V by default. This can result in network issues when the host computer is restarted.
+If you're on Windows, you should also check out the notes [here](../../../../docs/reference/local-tips-and-tricks.md) since Minishift and CRC rely on Windows Hyper-V by default. This can result in network issues when the host computer is restarted.
 
 
 ## Appendix B - Example values.yaml file for Helm Quickstart

--- a/vuepress/docs/next/tutorials/micro-frontends/react.md
+++ b/vuepress/docs/next/tutorials/micro-frontends/react.md
@@ -6,10 +6,7 @@ sidebarDepth: 2
 
 ::: warning Prerequisites
 - [A working instance of Entando.](../../docs/getting-started)
-:::
-
-::: warning Tested Versions
-node v13.8.0 → We suggest using [nvm](https://github.com/nvm-sh/nvm) to handle node installations.
+- Use the Entando CLI to verify you have the command line prerequisites in place for this tutorial (e.g. npm).
 :::
 
 ## Create React App
@@ -196,7 +193,7 @@ If you're getting started with a new install of Entando, let's add our widget to
 
 - This will take you to a blank home page with your widget.
 
-10. Copy the `Resource URL`.
+10. Copy the `Resource URL`. For example, this is the URL in a quickstart environment set up via the Getting Started guide:
 
 ```
 /entando-de-app/cmsresources/
@@ -204,28 +201,18 @@ If you're getting started with a new install of Entando, let's add our widget to
 
 ## Build It
 
-Now that we have the resource URL where we'll host our `Create React App`, we're ready to build.
+Now that we have the Resource URL where we'll host our `Create React App`, we're ready to build.
 
-1. Create an `.env` file in the project root of your `Create React App`.
+1. Create an `.env.production` file in the project root of your `Create React App`. 
 
 2. Add the `PUBLIC_URL` where we'll be hosting our files.
 
-Example:
-
 ```
-PUBLIC_URL=http://quickstart-entando.192.168.64.34.nip.io/entando-de-app/cmsresources/my-widget
+PUBLIC_URL=/entando-de-app/cmsresources/my-widget
 ```
-
-3. Replace `quickstart-entando.192.168.64.34.nip.io/entando-de-app` with the URL for your Entando application.
-
 ::: warning Notes
-- `quickstart-entando.192.168.64.34.nip.io` represents the base URL for your Entando application
 - `/entando-de-app/cmsresources/` is the Resource URL for your Entando application
 - `/my-widget` is the public folder we'll create to host our files
-:::
-
-::: tip
-[When you run `npm run build`, `Create React App` will substitute `%PUBLIC_URL%` with a correct absolute path so your project works even if you use client-side routing or host it at a non-root URL.](https://create-react-app.dev/docs/using-the-public-folder/)
 :::
 
 ### npm build

--- a/vuepress/docs/next/tutorials/micro-frontends/react.md
+++ b/vuepress/docs/next/tutorials/micro-frontends/react.md
@@ -216,12 +216,12 @@ Example:
 PUBLIC_URL=http://quickstart-entando.192.168.64.34.nip.io/entando-de-app/cmsresources/my-widget
 ```
 
-3. Replace `quickstart-entando.192.168.64.34.nip.io/app-builder` with the URL for your Entando App Builder instance. → [How to find your Entando App Builder URL.](../../docs/getting-started/#deploy-entando)
+3. Replace `quickstart-entando.192.168.64.34.nip.io/entando-de-app` with the URL for your Entando application.
 
 ::: warning Notes
-- `quickstart-entando.192.168.64.34.nip.io` represents your `Entando App Builder` instance.
-- `/entando-de-app/cmsresources/` is your Resource URL
-- `my-widget` is the public folder we'll create to host our files
+- `quickstart-entando.192.168.64.34.nip.io` represents the base URL for your Entando application
+- `/entando-de-app/cmsresources/` is the Resource URL for your Entando application
+- `/my-widget` is the public folder we'll create to host our files
 :::
 
 ::: tip

--- a/vuepress/docs/v6.3/docs/getting-started/README.md
+++ b/vuepress/docs/v6.3/docs/getting-started/README.md
@@ -16,7 +16,7 @@ The following steps will launch an Ubuntu VM via Multipass, install Kubernetes, 
 ``` http request
 https://multipass.run/#install
 ```
-2. Install Entando via the [Entando CLI](../reference/entando-cli.md) 
+2. Install Entando in an Ubuntu VM via the [Entando CLI](../reference/entando-cli.md) 
 
 ```sh
 curl -sfL https://get.entando.org | bash
@@ -209,7 +209,7 @@ database connection.
 Entando sets up `Ingresses` in Kubernetes to access services from outside your server cluster.
 We'll use this to access Entando from a local browser. 
 
-If you run into network issues during startup or if you are using Windows for your local development instance, please see [the tips](../../tutorials/devops/local-tips-and-tricks.md#network-issues). Symptoms can include having Entando fail to completely start the first time or a working Entando installation may fail to restart later. 
+If you run into network issues during startup or if you are using Windows for your local development instance, please see [the tips](../reference/local-tips-and-tricks.md#network-issues). Symptoms can include having Entando fail to completely start the first time or a working Entando installation may fail to restart later. 
 :::
 
 To set up external access to your cluster, you'll need to replace the value of
@@ -401,8 +401,17 @@ We now have Entando up and running on Kubernetes in our local environment.
 :::
 
 ---
+## Next Steps
+Choose one of the following actions to continue your journey with Entando!
+ 
+* **Build Your First Application:** Use the [Welcome Wizard](./welcome-wizard.md) to build your first application via guided prompts. 
 
-Follow the steps in the [Welcome Wizard](./welcome-wizard.md) to build your first application or see the other [Docs](../) and [Tutorials](../../tutorials/) to continue your journey with Entando!
+* **Try a Tutorial:** Take advantage of the [Learning Paths](../../tutorials/#learning-paths) which organize a few of the most popular tutorials by user type.
 
---
+* **Dig Deeper into Entando Concepts:** Review the [Docs](../) sections to more deeply understand the Entando building blocks.
+
+* **Learn about the Quickstart Environment:** See the [Quickstart Tips](../reference/local-tips-and-tricks.md) for more information on how to manage your Getting Started or quickstart environment.  
+
+---
+
 

--- a/vuepress/docs/v6.3/docs/reference/local-tips-and-tricks.md
+++ b/vuepress/docs/v6.3/docs/reference/local-tips-and-tricks.md
@@ -6,7 +6,7 @@ redirectFrom: /v6.3/tutorials/devops/local-tips-and-tricks.html
 We've collected a list of tips and tricks for optimizing your local quickstart or [Getting Started](../../docs/getting-started/) development environment. We invite you to ask questions, collaborate with the community, and share your own favorite 
 practices over on the [Entando forum](https://forum.entando.org).
 
-## Managing the Quickstart Environment
+## Quickstart Management
 Here are a few common questions about the quickstart environment which uses Multipass to launch an Ubuntu VM, install K3s Kubernetes into it, and then deploy Entando.
  
 ### Multipass
@@ -23,7 +23,7 @@ Here are a few common questions about the quickstart environment which uses Mult
 ## Shared Servers
 We've recommended using Multipass as a way to quickly spin up an Ubuntu VM to host a local Kubernetes cluster for test purposes. There are many times when a local environment is useful but most teams utilize a shared Kubernetes cluster managed by an operations team and installed either on premise or with a cloud provider for full integration testing, CI/CD, DevOps, etc. 
 
-## Network issues
+## Network Issues
 A local Entando 6.3 quickstart installation (e.g. what you'll get if you follow the [Getting Started](../../docs/getting-started/) guide) may use a set of local domain names to enable accessing Entando services. Your IP address will vary but may look something like this:
 ```
 quickstart-entando.192.168.99.1.nip.io
@@ -46,8 +46,8 @@ The base domain configured via the ENTANDO_DEFAULT_ROUTING_SUFFIX (e.g. in your 
 - The workaround noted above (e.g. update your /etc/hosts file) can also be used here. Simply update the IP address in the first column to use the current IP of your virtual machine. 
 - On Windows this can happen simply because your laptop restarted. See [Windows Hyper-V IP Changes](#hyper-v-ip-changes) below. 
 
-## Windows development
-### Hyper-V IP changes
+## Windows Development
+### Hyper-V IP Changes
 **Q:** My Entando installation stops working when I restart Windows. How can I fix this?
 
 **A:** The basic issue is that Windows Hyper-V makes it difficult to set a static IP for a VM. (See this [forum post](https://techcommunity.microsoft.com/t5/windows-insider-program/hyper-v-default-switch-ip-address-range-change-ver-1809-build/m-p/261431) for details.) As discussed [above](#network-issues), Entando's ingress routes rely on an fixed IP address and will break if the IP address changes after initial installation. Here are a few options to solve this issue, short of modifying your router or network switch settings: 

--- a/vuepress/docs/v6.3/tutorials/README.md
+++ b/vuepress/docs/v6.3/tutorials/README.md
@@ -1,8 +1,7 @@
 ---
-sidebarDepth: 0
+sidebarDepth: 2
 ---
 # Tutorials 
-## Overview
 
 ::: tip Entando simplifies the development of modern apps:
 
@@ -15,7 +14,8 @@ Entando supports full stack micro frontend and microservice architectures for co
 
 Use the navigation on the left to find step-by-step tutorials for common tasks or check out our learning paths below for a more structured approach.
 
-## Frontend Developers
+## Learning Paths
+### Frontend Developers
 
 <style>
 table th:first-of-type {
@@ -37,7 +37,7 @@ table th:nth-of-type(3) {
 | [Create and Manage Content](./cms/content-tutorial.md)| |
 
 
-## Backend Developers
+### Backend Developers
 
 | Basic | Intermediate | Advanced
 | :-: | :-: | :-:
@@ -45,7 +45,7 @@ table th:nth-of-type(3) {
 | [Generate Micro Frontends and Microservices Based on a Database Entity](./backend-developers/generate-microservices-and-micro-frontends.md) | [Export a Bundle from an Existing Application](./ecr/export-bundle-from-application.md) | 
 | [Run Micro Frontends and Microservices in your local env](./backend-developers/run-local.md) |Use JDL Studio to Create a Complex Database Entity (Coming Soon)  |
 
-## DevOps
+### DevOps
 
 | Basic | Intermediate | Advanced
 | :-: | :-: | :-:

--- a/vuepress/docs/v6.3/tutorials/devops/installation/open-shift/openshift-install.md
+++ b/vuepress/docs/v6.3/tutorials/devops/installation/open-shift/openshift-install.md
@@ -140,7 +140,7 @@ http://quickstart-entando.192.168.64.10.nip.io/app-builder/
 
 If you see errors when images are being retrieved (resulting in errors like ErrImagePull or ImagePullBackOff), you may want to start crc using ```crc start -n "8.8.8.8``` or configure the nameserver using ```crc config set nameserver 8.8.8.8``` before running ```crc start```. This will allow the cluster to perform DNS lookups via Google's public DNS server.
 
-If you're on Windows, you should also check out the notes [here](../../local-tips-and-tricks.md) since Minishift and CRC rely on Windows Hyper-V by default. This can result in network issues when the host computer is restarted.
+If you're on Windows, you should also check out the notes [here](../../../../docs/reference/local-tips-and-tricks.md) since Minishift and CRC rely on Windows Hyper-V by default. This can result in network issues when the host computer is restarted.
 
 
 ## Appendix B - Example values.yaml file for Helm Quickstart

--- a/vuepress/docs/v6.3/tutorials/micro-frontends/react.md
+++ b/vuepress/docs/v6.3/tutorials/micro-frontends/react.md
@@ -6,10 +6,7 @@ sidebarDepth: 2
 
 ::: warning Prerequisites
 - [A working instance of Entando.](../../docs/getting-started)
-:::
-
-::: warning Tested Versions
-node v13.8.0 → We suggest using [nvm](https://github.com/nvm-sh/nvm) to handle node installations.
+- Use the Entando CLI to verify you have the command line prerequisites in place for this tutorial (e.g. npm).
 :::
 
 ## Create React App
@@ -196,7 +193,7 @@ If you're getting started with a new install of Entando, let's add our widget to
 
 - This will take you to a blank home page with your widget.
 
-10. Copy the `Resource URL`.
+10. Copy the `Resource URL`. For example, this is the URL in a quickstart environment set up via the Getting Started guide:
 
 ```
 /entando-de-app/cmsresources/
@@ -204,28 +201,18 @@ If you're getting started with a new install of Entando, let's add our widget to
 
 ## Build It
 
-Now that we have the resource URL where we'll host our `Create React App`, we're ready to build.
+Now that we have the Resource URL where we'll host our `Create React App`, we're ready to build.
 
-1. Create an `.env` file in the project root of your `Create React App`.
+1. Create an `.env.production` file in the project root of your `Create React App`. 
 
 2. Add the `PUBLIC_URL` where we'll be hosting our files.
 
-Example:
-
 ```
-PUBLIC_URL=http://quickstart-entando.192.168.64.34.nip.io/entando-de-app/cmsresources/my-widget
+PUBLIC_URL=/entando-de-app/cmsresources/my-widget
 ```
-
-3. Replace `quickstart-entando.192.168.64.34.nip.io/entando-de-app` with the URL for your Entando application.
-
 ::: warning Notes
-- `quickstart-entando.192.168.64.34.nip.io` represents the base URL for your Entando application
 - `/entando-de-app/cmsresources/` is the Resource URL for your Entando application
 - `/my-widget` is the public folder we'll create to host our files
-:::
-
-::: tip
-[When you run `npm run build`, `Create React App` will substitute `%PUBLIC_URL%` with a correct absolute path so your project works even if you use client-side routing or host it at a non-root URL.](https://create-react-app.dev/docs/using-the-public-folder/)
 :::
 
 ### npm build

--- a/vuepress/docs/v6.3/tutorials/micro-frontends/react.md
+++ b/vuepress/docs/v6.3/tutorials/micro-frontends/react.md
@@ -216,12 +216,12 @@ Example:
 PUBLIC_URL=http://quickstart-entando.192.168.64.34.nip.io/entando-de-app/cmsresources/my-widget
 ```
 
-3. Replace `quickstart-entando.192.168.64.34.nip.io/app-builder` with the URL for your Entando App Builder instance. → [How to find your Entando App Builder URL.](../../docs/getting-started/#deploy-entando)
+3. Replace `quickstart-entando.192.168.64.34.nip.io/entando-de-app` with the URL for your Entando application.
 
 ::: warning Notes
-- `quickstart-entando.192.168.64.34.nip.io` represents your `Entando App Builder` instance.
-- `/entando-de-app/cmsresources/` is your Resource URL
-- `my-widget` is the public folder we'll create to host our files
+- `quickstart-entando.192.168.64.34.nip.io` represents the base URL for your Entando application
+- `/entando-de-app/cmsresources/` is the Resource URL for your Entando application
+- `/my-widget` is the public folder we'll create to host our files
 :::
 
 ::: tip


### PR DESCRIPTION
@w-caffiero-entando and @ichalagashvili ,

Here's my first take on this. I've added a set of next steps linked from the landing pages and the quickstart getting started guide: https://nshaw.github.io/v6.3/docs/getting-started/#next-steps. It points to the (now moved under docs) Tips document with a new Quickstart Management section which includes a handful of FAQ-style questions new users may have: https://nshaw.github.io/v6.3/docs/reference/local-tips-and-tricks.html#quickstart-management. I've pushed this to my GH Pages site for easier review. 
