### PR TITLE
ENDOC-57 Improve redirects from landing pages so the 404 page doesn't display

### DIFF
--- a/vuepress/docs/.vuepress/components/EntandoRedirect.vue
+++ b/vuepress/docs/.vuepress/components/EntandoRedirect.vue
@@ -1,0 +1,19 @@
+<template>
+</template>
+
+<script>
+/** From https://github.com/vuejs/vuepress/issues/239 */
+/** Redirects to the given 'to' url, which is relative to the current location. */
+export default {
+  name: 'Redirect',
+  props: {
+    to: {
+      type: String,
+      required: true
+    }
+  },
+  beforeMount() {
+    document.location.replace(this.to);
+  }
+}
+</script>

--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -1,6 +1,2 @@
-
-<script>
-var url = "/v6.3" + window.location.pathname;
-window.location = url;
-</script>
-
+Redirecting to the current Docs...
+<EntandoRedirect to="../v6.3/docs" />

--- a/vuepress/docs/docs/getting-started/README.md
+++ b/vuepress/docs/docs/getting-started/README.md
@@ -1,5 +1,2 @@
-
-<script>
-var url = "/v6.3" + window.location.pathname;
-window.location = url;
-</script>
+Redirecting to the current Getting Started guide...
+<EntandoRedirect to="../../v6.3/docs/getting-started" />

--- a/vuepress/docs/tutorials/README.md
+++ b/vuepress/docs/tutorials/README.md
@@ -1,5 +1,2 @@
-
-<script>
-var url = "/v6.3" + window.location.pathname;
-window.location = url;
-</script>
+Redirecting to the current Tutorials...
+<EntandoRedirect to="../v6.3/tutorials" />


### PR DESCRIPTION
This is visible on  my GH Pages - https://nshaw.github.io/docs/, https://nshaw.github.io/docs/getting-started, and https://nshaw.github.io/tutorials. If you watch closely you'll see a message about the redirect but I think that's preferable to a 404 (even temporary) and a full Vue reload.