### PR TITLE
Fix UX fragment code which must use an underscore instead of dash

### DIFF
--- a/vuepress/docs/v6.3/docs/ecr/ecr-bundle-details.md
+++ b/vuepress/docs/v6.3/docs/ecr/ecr-bundle-details.md
@@ -184,7 +184,7 @@ Here is an example of a widget descriptor:
 
 **Fragment descriptor.yaml.**
 
-    code: my-fragment # The unique id
+    code: my_fragment # The unique id
 
     # Optional. The fragment content
     guiCode: >-


### PR DESCRIPTION
Also fix the current doc