### PR TITLE
ENDOC-352 Remove login link from landing page

### DIFF
--- a/vuepress/docs/.vuepress/components/SpecialLayout.vue
+++ b/vuepress/docs/.vuepress/components/SpecialLayout.vue
@@ -29,11 +29,7 @@
           </li>
         </ul>
 
-        <div class="top-right-links">
-          <a href="https://www.entando.com/en/login_form.page">
-            LOGIN  <img src="./assets/account.svg">
-          </a>
-        </div>
+
 
         <div class="hamburger-menu" @click="toggleHamburgerMenu()"></div>
       </nav>


### PR DESCRIPTION
Remove the login link in the landing page top header since it points to the old login area of entando.com rather than keycloak