### PR TITLE
ENDOC-370 no support for M1 installation

### DIFF
--- a/vuepress/docs/next/docs/getting-started/README.md
+++ b/vuepress/docs/next/docs/getting-started/README.md
@@ -4,6 +4,10 @@ sidebarDepth: 2
 
 # Getting Started with Entando
 
+::: warning
+**Mac:** Entando 6 is not currently compatible with the Apple M1 ARM64 architecture found in some newer Macs.
+:::
+
 You have two options for getting started with Entando.
 1. [Automatically install Entando via the Entando command-line interface (CLI)](#automatic-install). This is the fastest way to start up an Entando application in Kubernetes.
 2. [Manually install Entando step by step](#manual-install). This is useful if you're preparing a shared cluster rather than a local developer environment, the CLI defaults don't meet your specific needs, or if you want to customize the deploy itself.

--- a/vuepress/docs/v6.3.2/docs/getting-started/README.md
+++ b/vuepress/docs/v6.3.2/docs/getting-started/README.md
@@ -4,7 +4,12 @@ sidebarDepth: 2
 
 # Getting Started with Entando
 
+::: warning
+**Mac:** Support for the Apple M1 platform is a work in progress and not offered by Entando 6.
+:::
+
 You have two options for getting started with Entando.
+
 1. [Automatically install Entando via the Entando command-line interface (CLI)](#automatic-install). This is the fastest way to start up an Entando application in Kubernetes.
 2. [Manually install Entando step by step](#manual-install). This is useful if you're preparing a shared cluster rather than a local developer environment, the CLI defaults don't meet your specific needs, or if you want to customize the deploy itself.
 

--- a/vuepress/docs/v6.3.2/docs/getting-started/README.md
+++ b/vuepress/docs/v6.3.2/docs/getting-started/README.md
@@ -5,11 +5,10 @@ sidebarDepth: 2
 # Getting Started with Entando
 
 ::: warning
-**Mac:** Support for the Apple M1 platform is a work in progress and not offered by Entando 6.
+**Mac:** Entando 6 is not currently compatible with the Apple M1 ARM64 architecture found in some newer Macs.
 :::
 
 You have two options for getting started with Entando.
-
 1. [Automatically install Entando via the Entando command-line interface (CLI)](#automatic-install). This is the fastest way to start up an Entando application in Kubernetes.
 2. [Manually install Entando step by step](#manual-install). This is useful if you're preparing a shared cluster rather than a local developer environment, the CLI defaults don't meet your specific needs, or if you want to customize the deploy itself.
 

--- a/vuepress/docs/v6.3.2/docs/releases/README.md
+++ b/vuepress/docs/v6.3.2/docs/releases/README.md
@@ -92,6 +92,9 @@
 
 ## Known Issues
 
+### Apple M1
+  - Entando does not currently support ARM64 architecture and cannot be installed on newer Macs built with the Apple M1 processor. Solutions are under investigation.
+
 ### Entando Component Generator
   - The default "detail" widget  generated for the entities doesn't work out of the box.
   - Local keycloak loses state across restarts when using --no-recreate option
@@ -99,9 +102,6 @@
 ### GKE
   - There is  a known issue with the current nginx ingress that can be worked around by using the `singleHost` option for the configuration of your Entando Applications and binding TLS to that single host path
     - The issue will be solved in the next minor or patch release (6.4.0 or 6.3.3)
-
-### Apple M1
-  - Entando does not currently support ARM64 architecture and cannot be installed on newer Macs built with the Apple M1 processor. The issue and possible solutions are under investigation.
 
 ## Deprecation Warnings
   - Support for version 1 and 2 of the plugin descriptor are deprecated and will be removed in the future

--- a/vuepress/docs/v6.3.2/docs/releases/README.md
+++ b/vuepress/docs/v6.3.2/docs/releases/README.md
@@ -100,5 +100,8 @@
   - There is  a known issue with the current nginx ingress that can be worked around by using the `singleHost` option for the configuration of your Entando Applications and binding TLS to that single host path
     - The issue will be solved in the next minor or patch release (6.4.0 or 6.3.3)
 
+### Apple M1
+  - Entando does not currently support ARM64 architecture and cannot be installed on newer Macs built with the Apple M1 processor. The issue and possible solutions are under investigation.
+
 ## Deprecation Warnings
   - Support for version 1 and 2 of the plugin descriptor are deprecated and will be removed in the future


### PR DESCRIPTION
ENDOC-370 No Entando support for Apple's M1 chip noted in Getting Started and the Known Issues section of Release Notes