### PR TITLE
ENDOC-398 Update the Standard Demo cache workaround to use the easier Reload Configuration option

### DIFF
--- a/vuepress/docs/next/tutorials/samples/install-standard-demo.md
+++ b/vuepress/docs/next/tutorials/samples/install-standard-demo.md
@@ -19,7 +19,7 @@ bundles. This solution template includes
 The goal of this exercise is to demonstrate how Entando bundles can be used to 
 
 - quickly install and create functionality in an Entando Application
-- enable portable business capabilities
+- enable packaged business capabilities
 - allow developers to reuse full stack operations via bundles
 
 Some of the key elements of the template are reviewed in the [application details section](#application-details) below.
@@ -57,7 +57,7 @@ ent bundler from-git -d -r https://github.com/entando-samples/standard-demo-cont
 4. Select `Install` for each bundle, where order of installation is important. The `standard-demo` bundle will need to be installed last, as it relies on MFEs from the other bundles to set up each of the pages. 
    ![Installed.png](./images/Installed.png)
 
-Each installation can take several minutes, while the application downloads the Linux images for the microservices and installs the related assets. The `sd-banking` and `sd-customer bundles` include microservices that require the initialization of containers and will take longer to install.
+Each installation can take several minutes while the application downloads the Linux images for the microservices and installs the related assets. The `sd-banking` and `sd-customer bundles` include microservices that require the initialization of containers and will take longer to install.
 
 In the unlikely event you encounter conflicts during an initial installation, you will be presented with an Installation Plan like the one shown below. Select `Update All` in the upper right after making your selections.
    ![InstallPlan.png](./images/InstallPlan.png)
@@ -80,13 +80,11 @@ You can now navigate to your application's home page using the home icon in the 
 ![Homepage.png](./images/Homepage.png)
 
 :::warning 
-(Entando 6.3.2) There can be a cache issue when initially deploying the `sd-content` bundle, where not all widgets or MFEs appear on some pages, particularly the Dashboard page. 
+(Entando 6.3.2) A cache issue impacting the first deployment of the `sd-content` bundle can prevent all widgets or MFEs from appearing on some pages, particularly the Dashboard page. 
 
 To clear the cache, select `Adniminstration` from the bottom of the left menu, then `Reload configuration`.
 
 Alternatively, restarting the quickstart-server pod (which contains the Entando App Engine) will also clear the cache, and can be achieved with `ent k delete pod/<YOUR QUICKSTART-SERVER POD>`, e.g. `ent k delete pod/quickstart-server-deployment-5d785b997c-r4sc8`. It will take several minutes for the pod to redeploy after deletion. 
-
-Note that needing to clear the cache is only applicable to the first install. 
 :::
 
 ## Application Details
@@ -101,7 +99,7 @@ The Entando Standard Banking Demo application demonstrates a number of the major
 
 ### Micro Frontends (MFE)
 
-The application includes six custom micro frontends, in which the above features complement one another to achieve custom functionality. These are described below.
+The application includes six MFEs in which the above features complement one another to achieve custom functionality. These are described below.
 
 #### 1. Card
 

--- a/vuepress/docs/next/tutorials/samples/install-standard-demo.md
+++ b/vuepress/docs/next/tutorials/samples/install-standard-demo.md
@@ -9,20 +9,20 @@ sidebarDepth: 2
 ## Introduction
 
 This tutorial will guide you through installing a demo application using the Entando Component Repository (ECR) and a set of Entando
-bundles. This solution template includes 
+bundles. This solution template includes: 
 
 - microservices
 - micro frontends
 - multiple pages
 - CMS content
 
-The goal of this exercise is to demonstrate how Entando bundles can be used to 
+The goal of this exercise is to demonstrate how Entando bundles can be used to: 
 
 - quickly install and create functionality in an Entando Application
 - enable packaged business capabilities
 - allow developers to reuse full stack operations via bundles
 
-Some of the key elements of the template are reviewed in the [application details section](#application-details) below.
+Some of the key elements of the template are reviewed in the [Application Details section](#application-details) below.
 
 ## Installation
 
@@ -63,9 +63,6 @@ In the unlikely event you encounter conflicts during an initial installation, yo
    ![InstallPlan.png](./images/InstallPlan.png)
 
 
-
-
-
 5. Access the Standard Banking Demo via one of the following options:
 
 **Option 1** If you'd like to make the Standard Banking Demo your default home page, go to `App Builder → Pages → Settings`. In
@@ -82,7 +79,7 @@ You can now navigate to your application's home page using the home icon in the 
 :::warning 
 (Entando 6.3.2) A cache issue impacting the first deployment of the `sd-content` bundle can prevent all widgets or MFEs from appearing on some pages, particularly the Dashboard page. 
 
-To clear the cache, select `Adniminstration` from the bottom of the left menu, then `Reload configuration`.
+To clear the cache, select `Administration` from the bottom of the left menu, then `Reload configuration`.
 
 Alternatively, restarting the quickstart-server pod (which contains the Entando App Engine) will also clear the cache, and can be achieved with `ent k delete pod/<YOUR QUICKSTART-SERVER POD>`, e.g. `ent k delete pod/quickstart-server-deployment-5d785b997c-r4sc8`. It will take several minutes for the pod to redeploy after deletion. 
 :::

--- a/vuepress/docs/next/tutorials/samples/install-standard-demo.md
+++ b/vuepress/docs/next/tutorials/samples/install-standard-demo.md
@@ -8,18 +8,29 @@ sidebarDepth: 2
 
 ## Introduction
 
-This tutorial will guide you through installing a demo application using the Entando Component Repository and a set of Entando
-bundles. This solution template includes microservices, micro frontends, multiple pages, and CMS content. The goal of this exercise
-is to demonstrate how Entando bundles can be used to quickly install and create functionality in an Entando Application, enable portable business capabilities, and allow developers to reuse full stack operations via bundles.
+This tutorial will guide you through installing a demo application using the Entando Component Repository (ECR) and a set of Entando
+bundles. This solution template includes 
 
-Some of the key elements of the template are reviewed in
-the [application details section](#application-details) below.
+- microservices
+- micro frontends
+- multiple pages
+- CMS content
+
+The goal of this exercise is to demonstrate how Entando bundles can be used to 
+
+- quickly install and create functionality in an Entando Application
+- enable portable business capabilities
+- allow developers to reuse full stack operations via bundles
+
+Some of the key elements of the template are reviewed in the [application details section](#application-details) below.
 
 ## Installation
 
+There are numerous assets installed as part of the Standard Banking Demo. Entando Bundles can include more or less components, depending on objectives. It is recommended that organizations develop guidelines for bundle sizing that fit the goals of their applications and teams.
+
 ### Prerequisites
 
-- An Entando Application on any Kubernetes provider. Follow one of the [tutorials](../#operations) for your environment to install the Entando platform.
+- An Entando Application on any Kubernetes provider. Follow one of the [tutorials](../#operations) appropriate to your environment to install the Entando platform.
 - The ent command line tool, installed and connected to your Kubernetes instance.
 
 ### Installation Steps
@@ -40,40 +51,42 @@ ent bundler from-git -d -r https://github.com/entando-samples/standard-demo-cont
 
 2. Log into your App Builder instance.
 
-3. Select Repository from the menu on the left. Your bundles will be visible in the repository as shown in the screenshot
-   below.
+3. Select `Repository` from the menu on the left. Your bundles will be visible in the repository as shown in the screenshot below.
    ![Repository.png](./images/Repository.png)
 
-4. Select `Install` for each bundle, where order of installation is important. The `standard-demo` bundle will need to be installed last, as it relies on MFEs from the other bundles to set up each of the pages. The `sd-banking` and `sd-customer bundles` will take a few minutes, because they include microservices that require the initialization of containers. 
-
-5. In the unlikely event you encounter conflicts during an initial installation, you will be presented with an Installation Plan like the one shown below.
-   ![InstallPlan.png](./images/InstallPlan.png)
-
-Select `Update All` in the upper right after making your selections.
-
-6. Each installation can take several minutes, while the application downloads the Linux images for the microservices and installs the related assets.
+4. Select `Install` for each bundle, where order of installation is important. The `standard-demo` bundle will need to be installed last, as it relies on MFEs from the other bundles to set up each of the pages. 
    ![Installed.png](./images/Installed.png)
 
-:::warning 
-(Entando 6.3.2) There is a cache issue when initially deploying the `sd-content` bundle, where not all widgets or MFEs appear on some pages, particularly the Dashboard page. 
+Each installation can take several minutes, while the application downloads the Linux images for the microservices and installs the related assets. The `sd-banking` and `sd-customer bundles` include microservices that require the initialization of containers and will take longer to install.
 
-Restarting the quickstart-server pod (which contains the Entando App Engine) will clear the cache, and can be achieved with `ent k delete pod/<YOUR QUICKSTART-SERVER POD>`, e.g. `ent k delete pod/quickstart-server-deployment-5d785b997c-r4sc8`. It will take several minutes for the pod to redeploy after deletion. 
+In the unlikely event you encounter conflicts during an initial installation, you will be presented with an Installation Plan like the one shown below. Select `Update All` in the upper right after making your selections.
+   ![InstallPlan.png](./images/InstallPlan.png)
 
-Note that a restart is only applicable to the first install. 
-:::
 
-7. (Option 1) If you'd like to make the Standard Banking Demo your default home page, go to `App Builder → Pages → Settings`. In
+
+
+
+5. Access the Standard Banking Demo via one of the following options:
+
+**Option 1** If you'd like to make the Standard Banking Demo your default home page, go to `App Builder → Pages → Settings`. In
    the dropdown for Home Page, select `Home / Home SD` and click `Save`.
    ![HomepageSelect.png](./images/HomepageSelect.png)
 
 You can now navigate to your application's home page using the home icon in the upper right of the App Builder.
+
+
+**Option 2** Alternatively, you can view the Standard Banking Demo home page by going to `Pages → Management`, finding `Home SD` in the page tree, and clicking `View Published Page` from its actions.
+
 ![Homepage.png](./images/Homepage.png)
 
-8. (Option 2) Alternatively, you can view the Standard Banking Demo home page by going to `Pages → Management`,
-   finding `Home SD` in the page tree, and clicking `View Published Page` from its actions.
+:::warning 
+(Entando 6.3.2) There can be a cache issue when initially deploying the `sd-content` bundle, where not all widgets or MFEs appear on some pages, particularly the Dashboard page. 
 
-:::tip 
-There are numerous assets installed as part of the Standard Banking Demo. Entando Bundles can include more or less components, depending on objectives. It is recommended that organizations develop guidelines for bundle sizing that fit the goals of their applications and teams.
+To clear the cache, select `Adniminstration` from the bottom of the left menu, then `Reload configuration`.
+
+Alternatively, restarting the quickstart-server pod (which contains the Entando App Engine) will also clear the cache, and can be achieved with `ent k delete pod/<YOUR QUICKSTART-SERVER POD>`, e.g. `ent k delete pod/quickstart-server-deployment-5d785b997c-r4sc8`. It will take several minutes for the pod to redeploy after deletion. 
+
+Note that needing to clear the cache is only applicable to the first install. 
 :::
 
 ## Application Details
@@ -82,23 +95,20 @@ The Entando Standard Banking Demo application demonstrates a number of the major
 
 * Keycloak integration for role based access controls
 * Micro frontends implemented using React and Angular and co-existing on the same dashboard page
-* Micro front communication techniques
+* Micro frontend communication techniques
 * Microservices via Spring Boot
 * Entando Content Management
 
 ### Micro Frontends (MFE)
 
-The application includes six custom micro frontends, which are described below.
+The application includes six custom micro frontends, in which the above features complement one another to achieve custom functionality. These are described below.
 
 #### 1. Card
 
 ![SeedCard.png](./images/SeedCard.png)
 
-- The Card MFE is a React micro frontend that is visible on the My Dashboard page. The MFE makes an API call to
-  the banking microservice to fetch a numeric result depending on the configured card type. The value displayed will
-  change as the configuration is changed.
-- The MFE is authorization-aware and will pass the bearer token to the microservice for authorization and
-  authentication. If you render the dashboard page and you aren't authenticated, the widget displays an error message.
+- The Card MFE is a React micro frontend that is visible on the My Dashboard page. The MFE makes an API call to the banking microservice to fetch a numeric result depending on the configured card type. The displayed value will change as the configuration is changed.
+- The MFE is authorization-aware and will pass the bearer token to the microservice for authorization and authentication. If you render the dashboard page and you aren't authenticated, the widget displays an error message.
 - This MFE emits events that are consumed by the Transaction Table widget.
 
 #### 2. Card NG
@@ -112,8 +122,7 @@ The application includes six custom micro frontends, which are described below.
 
 
 
-- The Manage Users MFE makes an API call to Keycloak to fetch user information. When the user is logged into the app, the MFE is visible
-  from the dropdown under the username.
+- The Manage Users MFE makes an API call to Keycloak to fetch user information. When the user is logged into the app, the MFE is visible from the dropdown under the username.
 - By default, application users are not granted Keycloak authorization to manage users. This demonstrates role based access control for an MFE using Keycloak. To enable the Manage Users widget, login to Keycloak and assign the realm-management client's `view-users` and `manage-users` roles to the desired user.
 
 Authorized View
@@ -134,8 +143,7 @@ Not Authorized View
 #### 5. Sign Up
 
 
-- The Sign Up MFE is a form widget that makes an API call to the customer microservice to create a new user. The Sign Up
-  MFE is visible on the sign up page, and can be accessed from any page when a user is not authenticated.
+- The Sign Up MFE is a form widget that makes an API call to the customer microservice to create a new user. The Sign Up MFE is visible on the sign up page, and can be accessed from any page when a user is not authenticated.
 
   ![SignUp.png](./images/SignUp.png)
 
@@ -150,7 +158,7 @@ Not Authorized View
 
 ### Configuration Micro Frontends
 
-When placed on a page, many of the MFEs detailed above include configuration screens visible in the App Builder. In the App Builder, navigate to `Components → Micro frontends & Widgets` to see the configured MFEs. To see the rendered config screen, place the above MFEs on a new page.
+When placed on a page, many of the MFEs detailed above include configuration screens visible in the App Builder at `Components → Micro frontends & Widgets`. To see the rendered config screen, place the MFE on a new page.
 
 ### Microservices
 
@@ -164,12 +172,10 @@ The application uses static HTML, FreeMarker, and JavaScript widgets to display 
 
 ### Static CMS Content
 
-The application makes extensive use of the Entando CMS. This includes the creation of content templates, content types, and content. If you want to learn more about the Entando CMS in the application, log into the App Builder and select `Content →  Templates`, `Content → Management`, or `Content → Types`; these are good starting points to view the content and static assets.
+The application makes extensive use of the Entando CMS. This includes the creation of content templates, content types, and content. If you want to learn more about the Entando CMS in the application, log into the App Builder and select `Content →  Templates`, `Content → Management`, or `Content → Types`.
 
 
 
 ## Source Code
 
-The source code for the Entando Standard Banking Demo can be found with our other open source examples and tutorials on GitHub:
-
-<https://github.com/entando-samples/standard-demo>
+The source code for the Entando Standard Banking Demo can be found on GitHub [here](https://github.com/entando-samples/standard-demo), along with our other open source examples and tutorials.

--- a/vuepress/docs/v6.3.2/tutorials/samples/install-standard-demo.md
+++ b/vuepress/docs/v6.3.2/tutorials/samples/install-standard-demo.md
@@ -8,23 +8,34 @@ sidebarDepth: 2
 
 ## Introduction
 
-This tutorial will take you through installing a demonstration application using the Entando Component Repository and a set of Entando
-bundles. This solution template includes microservices, micro frontends, many pages, and CMS content. The goal of this install
-is to demonstrate how Entando bundles can be used to quickly install and create functionality in an Entando application, enable portable business capabilities, and can enable developers to re-use full stack functionality via a bundle.
+This tutorial will guide you through installing a demo application using the Entando Component Repository (ECR) and a set of Entando
+bundles. This solution template includes: 
 
-Some of the key elements of the template are reviewed in
-the [application details section](#application-details) below.
+- microservices
+- micro frontends
+- multiple pages
+- CMS content
+
+The goal of this exercise is to demonstrate how Entando bundles can be used to: 
+
+- quickly install and create functionality in an Entando Application
+- enable packaged business capabilities
+- allow developers to reuse full stack operations via bundles
+
+Some of the key elements of the template are reviewed in the [Application Details section](#application-details) below.
 
 ## Installation
 
+There are numerous assets installed as part of the Standard Banking Demo. Entando Bundles can include more or less components, depending on objectives. It is recommended that organizations develop guidelines for bundle sizing that fit the goals of their applications and teams.
+
 ### Prerequisites
 
-- An Entando application on any Kubernetes provider. Follow one of the [tutorials](../#operations) for your platform to install the Entando platform
-- The ent command line tool installed and connected to your Kubernetes instance.
+- An Entando Application on any Kubernetes provider. Follow one of the [tutorials](../#operations) appropriate to your environment to install the Entando platform.
+- The ent command line tool, installed and connected to your Kubernetes instance.
 
 ### Installation Steps
 
-1. Apply the definitions for the four bundles that make up the Standard Banking Demo. You'll need to adjust the `-n entando` option in each command to match your namespace or project.
+1. Apply the definitions for the four bundles that comprise the Standard Banking Demo. You'll need to adjust the `-n entando` option in each command to match your namespace or project.
 ```
 ent bundler from-git -d -r https://github.com/entando-samples/standard-demo-banking-bundle.git | ent kubectl apply -n entando -f -
 ```
@@ -38,74 +49,76 @@ ent bundler from-git -d -r https://github.com/entando-samples/standard-demo-mana
 ent bundler from-git -d -r https://github.com/entando-samples/standard-demo-content-bundle.git | ent kubectl apply -n entando -f -
 ```
 
-2. Log into your App Builder instance
+2. Log into your App Builder instance.
 
-3. Select Repository from the menu on the left. Your bundles will be visible in the repository as shown in the screenshot
-   below
+3. Select `Repository` from the menu on the left. Your bundles will be visible in the repository as shown in the screenshot below.
    ![Repository.png](./images/Repository.png)
 
-4. Select `Install` for each bundle. The `sd-banking` and `sd-customer bundles` will take a few minutes since they include microservices that require starting up containers. The `standard-demo` bundle will need to be installed last since it depends on MFEs from the other bundles in order to set up each of the pages.
-
-5. You should not see any conflicts in an initial installation but if there are any conflicts you will be presented with an Installation Plan like the one shown below.
-   ![InstallPlan.png](./images/InstallPlan.png)
-
-Select `Update All` in the upper right after making your selections.
-
-6. Each installation can take a few minutes as the application downloads the Linux images for the microservices and installs all of the related assets.
+4. Select `Install` for each bundle, where order of installation is important. The `standard-demo` bundle will need to be installed last, as it relies on MFEs from the other bundles to set up each of the pages. 
    ![Installed.png](./images/Installed.png)
 
-:::warning
-(Entando 6.3.2) There is a cache issue when deploying the `sd-content` bundle which means not all widgets or MFEs initially appear on some pages, particularly the Dashboard page. Restarting the quickstart-server pod (which holds the Entando App Engine) will clear the cache. This is only necessary on the initial install.
-:::
+Each installation can take several minutes while the application downloads the Linux images for the microservices and installs the related assets. The `sd-banking` and `sd-customer bundles` include microservices that require the initialization of containers and will take longer to install.
 
-7. (Option 1) If you'd like to make the Standard Banking Demo your default home page, go to `App Builder → Pages → Settings`. In
-   the dropdown for Home Page select `Home / Home SD` and click `Save`.
+In the unlikely event you encounter conflicts during an initial installation, you will be presented with an Installation Plan like the one shown below. Select `Update All` in the upper right after making your selections.
+   ![InstallPlan.png](./images/InstallPlan.png)
+
+
+5. Access the Standard Banking Demo via one of the following options:
+
+**Option 1** If you'd like to make the Standard Banking Demo your default home page, go to `App Builder → Pages → Settings`. In
+   the dropdown for Home Page, select `Home / Home SD` and click `Save`.
    ![HomepageSelect.png](./images/HomepageSelect.png)
 
-You can now navigate to your applications home page using the home icon in the upper right of the app builder to view
-the application homepage
+You can now navigate to your application's home page using the home icon in the upper right of the App Builder.
+
+
+**Option 2** Alternatively, you can view the Standard Banking Demo home page by going to `Pages → Management`, finding `Home SD` in the page tree, and clicking `View Published Page` from its actions.
+
 ![Homepage.png](./images/Homepage.png)
 
-8. (Option 2) Alternatively, you can simply view the Standard Banking Demo home page by going to `Pages → Management`,
-   finding `Home SD` in the page tree, and clicking `View Published Page` from its actions.
+:::warning 
+(Entando 6.3.2) A cache issue impacting the first deployment of the `sd-content` bundle can prevent all widgets or MFEs from appearing on some pages, particularly the Dashboard page. 
 
-:::tip
-There are many assets installed as part of the Standard Banking Demo. Entando Bundles can include many components like the `sd-content` bundle or smaller depending on the goals of your team. It is recommended that organizations develop guidelines for bundle sizing that fit the goals of their applications and teams.
+To clear the cache, select `Administration` from the bottom of the left menu, then `Reload configuration`.
+
+Alternatively, restarting the quickstart-server pod (which contains the Entando App Engine) will also clear the cache, and can be achieved with `ent k delete pod/<YOUR QUICKSTART-SERVER POD>`, e.g. `ent k delete pod/quickstart-server-deployment-5d785b997c-r4sc8`. It will take several minutes for the pod to redeploy after deletion. 
 :::
 
 ## Application Details
 
-The Entando Standard Banking Demo application demonstrates a number of the major features in the Entando platform including:
+The Entando Standard Banking Demo application demonstrates a number of the major features of the Entando platform, including:
 
 * Keycloak integration for role based access controls
 * Micro frontends implemented using React and Angular and co-existing on the same dashboard page
-* Micro front communication techniques
-* Microservices run via Spring Boot
+* Micro frontend communication techniques
+* Microservices via Spring Boot
 * Entando Content Management
 
 ### Micro Frontends (MFE)
 
-The application includes six custom micro frontends which are described below.
+The application includes six MFEs in which the above features complement one another to achieve custom functionality. These are described below.
 
 #### 1. Card
 
 ![SeedCard.png](./images/SeedCard.png)
 
-- The Card MFE is a React micro frontend that is visible on the My Dashboard page. The MFE makes an API call to
-  the banking microservice to fetch a numeric result depending on the configured card type. The value displayed will
-  change as the configuration is changed.
-- The MFE is authorization-aware and will pass the bearer token to the microservice for authorization and
-  authentication. If you render the dashboard page and you aren't authenticated the widget shows an error message.
-- This widget emits events that are consumed by the Transaction Table widget.
+- The Card MFE is a React micro frontend that is visible on the My Dashboard page. The MFE makes an API call to the banking microservice to fetch a numeric result depending on the configured card type. The displayed value will change as the configuration is changed.
+- The MFE is authorization-aware and will pass the bearer token to the microservice for authorization and authentication. If you render the dashboard page and you aren't authenticated, the widget displays an error message.
+- This MFE emits events that are consumed by the Transaction Table widget.
 
 #### 2. Card NG
 
 ![SeedCardNG.png](./images/SeedCardNG.png)
 
-- The Card NG MFE is an Angular widget that is similar to the Card widget above except for the choice of front end technology.
-- This MFE communicates with Transaction Table widget which is implemented in React.
+- The Card NG MFE is an Angular widget that is similar to the Card widget above, except for the choice of frontend technology.
+- This MFE communicates with the Transaction Table widget, which is implemented in React.
 
 #### 3. Manage Users
+
+
+
+- The Manage Users MFE makes an API call to Keycloak to fetch user information. When the user is logged into the app, the MFE is visible from the dropdown under the username.
+- By default, application users are not granted Keycloak authorization to manage users. This demonstrates role based access control for an MFE using Keycloak. To enable the Manage Users widget, login to Keycloak and assign the realm-management client's `view-users` and `manage-users` roles to the desired user.
 
 Authorized View
 ![ManageUsersAuth.png](./images/ManageUsersAuth.png)
@@ -113,60 +126,51 @@ Authorized View
 Not Authorized View
 ![ManageUsersNoAuth.png](./images/ManageUsersNoAuth.png)
 
-- The Manage Users MFE makes an API call to Entando Identity Management to fetch user information. The MFE is visible
-  under the dropdown under the username when the user is logged into the app.
-- By default the users provisioned in the application do not include the authorization required to manage users in
-  Entando Identity Management. This is used to demonstrate role based access control for an MFE using Keycloak. To
-  enable the Manage Users widget login to Keycloak and assign the `view-users` and `manage-users` roles from the
-  realm-management client to the desired user.
-
 #### 4. Transaction Table
+
+
+
+- This MFE is a React micro frontend that consumes events from the Card MFEs detailed above.
+- The Transaction Table widget makes an API call to the banking microservice to fetch transaction data for the user.
 
 ![TransactionTable.png](./images/TransactionTable.png)
 
-- This MFE is a React micro frontend that consumes events from the Card MFEs detailed above.
-- The Transaction Table widget makes an API call to the banking microservice to fetch transaction data for the logged in
-  user.
+#### 5. Sign Up
 
-#### 5. Signup
 
-![SignUp.png](./images/SignUp.png)
+- The Sign Up MFE is a form widget that makes an API call to the customer microservice to create a new user. The Sign Up MFE is visible on the sign up page, and can be accessed from any page when a user is not authenticated.
 
-- The Sign Up MFE is a form widget that makes an API call to the customer microservice to create a new user. The Signup
-  MFE is visible on the sign up page and can be accessed from any page when a user is not authenticated.
+  ![SignUp.png](./images/SignUp.png)
 
-#### 6. Alert Icons
+#### 6. Alert Icon
+
+
+
+- The Alert Icon MFE displays an icon on the dashboard page. It includes a configuration MFE to allow the user to select the appropriate icon and datatype to display.
+- In the default deployment, the Alert Icon MFE makes an API call to the banking microservice to fetch data.
 
 ![AlertIcons.png](./images/AlertIcons.png)
 
-- The Alert Icon MFE displays an icon on the dashboard page and includes a configuration MFE to allow the user to select
-  the appropriate icon and datatype to display.
-- The Alert Icon MFE makes an API call to the banking microservice to fetch data in the default deployment.
-
 ### Configuration Micro Frontends
 
-Many of the MFEs detailed above include configuration screens visible in the App Builder when the MFE is placed on a page. In the App Builder navigate to `Components → Micro frontends & Widgets` to see the configured MFEs. To see the rendered config screen place the MFEs above on a new page.
+When placed on a page, many of the MFEs detailed above include configuration screens visible in the App Builder at `Components → Micro frontends & Widgets`. To see the rendered config screen, place the MFE on a new page.
 
 ### Microservices
 
-The application includes two microservices (service paths: `/banking` and `/customer`) to support the data visible in the MFEs detailed above. Both microservices demonstrate the automated deployment and linking of a microservice to an Entando application via the Entando operator.
+The application includes two microservices (service paths: `/banking` and `/customer`) to support the data visible in the MFEs detailed above. Both microservices demonstrate the automated deployment and linking of a microservice to an Entando Application via the Entando Operator.
 
-The data for the microservices is created using Liquibase and demonstrates using the operator and Liquibase + Spring Boot to automatically provision data into an environment. The demo data is available in the source code for the microservices on GitHub.
+The data for the microservices are created with Liquibase, demonstrating the use of the Operator and Liquibase + Spring Boot to automatically provision data into an environment. The demo data is available in the source code for the microservices on GitHub.
 
 ### Static Widgets
 
-The application uses static HTML, FreeMarker, and JavaScript widgets to display content including headers, footers,
-images and other content in the application. To view the static widgets log into the App builder and
-select `Components → Micro frontends & Widgets`
+The application uses static HTML, FreeMarker, and JavaScript widgets to display content, e.g. headers, footers, images, etc. To view the static widgets, log into the App builder and select `Components → Micro frontends & Widgets`.
 
 ### Static CMS Content
 
-The application makes extensive use of the Entando CMS. This includes the creation of content templates, content types, and content. If you want to learn more about the Entando CMS in the application log into the App Builder and select `Content →  Templates`, `Content → Management`, or `Content → Types` as good starting points to view the content and static assets.
+The application makes extensive use of the Entando CMS. This includes the creation of content templates, content types, and content. If you want to learn more about the Entando CMS in the application, log into the App Builder and select `Content →  Templates`, `Content → Management`, or `Content → Types`.
 
 
 
 ## Source Code
 
-The source for the Entando Standard Banking Demo can be found with our other open source examples and tutorials on GitHub at:
-
-<https://github.com/entando-samples/standard-demo>
+The source code for the Entando Standard Banking Demo can be found on GitHub [here](https://github.com/entando-samples/standard-demo), along with our other open source examples and tutorials.


### PR DESCRIPTION
This commit adds the cache clearing workaround and also reorganizes material to flow better with cleaner presentation.

among other offenses, the previous rev: 

- listed a troubleshooting issue as an installation step
- separated 2 options to achieve the same result into 2 different installation steps, and 
- did not explain how to navigate to the demo page until after the fix for missing content was discussed - cue frustrated fumbling and confusion between similar menu options (my dashboard on the demo page vs dashboard in the app)

i'm not happy with it, but it's an improvement. i'd still love to shoot for one-liners wrt step-by-step tutorials...