### PR TITLE
ENDOC-404 Broken anchor link in Concepts section for 6.3.2

### DIFF
--- a/vuepress/docs/next/docs/concepts/README.md
+++ b/vuepress/docs/next/docs/concepts/README.md
@@ -74,8 +74,8 @@ An Entando application is composed of three parts:
 
 3.  **Entando Component Manager**: the service providing the Entando
     Component Repository functionality, e.g. listing the available
-    bundles, install/uninstall a bundle, etc. Check the [dedicated
-    section](#ecm-section) for more details.
+    bundles, install/uninstall a bundle, etc. Check the dedicated Entando Component Management
+    section below for more details.
 
 The interaction between these three components (and the rest of the
 Entando cluster) use the authorization/authentication features provided

--- a/vuepress/docs/next/docs/concepts/README.md
+++ b/vuepress/docs/next/docs/concepts/README.md
@@ -74,8 +74,7 @@ An Entando application is composed of three parts:
 
 3.  **Entando Component Manager**: the service providing the Entando
     Component Repository functionality, e.g. listing the available
-    bundles, install/uninstall a bundle, etc. Check the dedicated Entando Component Management
-    section below for more details.
+    bundles, install/uninstall a bundle, etc.
 
 The interaction between these three components (and the rest of the
 Entando cluster) use the authorization/authentication features provided

--- a/vuepress/docs/v6.3.2/docs/concepts/README.md
+++ b/vuepress/docs/v6.3.2/docs/concepts/README.md
@@ -74,8 +74,8 @@ An Entando application is composed of three parts:
 
 3.  **Entando Component Manager**: the service providing the Entando
     Component Repository functionality, e.g. listing the available
-    bundles, install/uninstall a bundle, etc. Check the [dedicated
-    section](#ecm-section) for more details.
+    bundles, install/uninstall a bundle, etc. Check the dedicated Entando Component Management
+    section below for more details.
 
 The interaction between these three components (and the rest of the
 Entando cluster) use the authorization/authentication features provided

--- a/vuepress/docs/v6.3.2/docs/concepts/README.md
+++ b/vuepress/docs/v6.3.2/docs/concepts/README.md
@@ -74,8 +74,7 @@ An Entando application is composed of three parts:
 
 3.  **Entando Component Manager**: the service providing the Entando
     Component Repository functionality, e.g. listing the available
-    bundles, install/uninstall a bundle, etc. Check the dedicated Entando Component Management
-    section below for more details.
+    bundles, install/uninstall a bundle, etc.
 
 The interaction between these three components (and the rest of the
 Entando cluster) use the authorization/authentication features provided


### PR DESCRIPTION
The link doesn't work because a) the sidebar depth isn't high enough to differentiate the cited subsection, or b) the subsection directly follows the list item so the link appears nonfunctional to the user (the view of the page would not shift/scroll upon clicking). Given the proximity of subsection reference and subsection including a link is awkward and unnecessary.