### PR TITLE
ENDOC-430 Insert cross-reference links

### DIFF
--- a/vuepress/docs/next/docs/compose/app-builder.md
+++ b/vuepress/docs/next/docs/compose/app-builder.md
@@ -14,7 +14,7 @@ Pages are designed and embedded with functionality via drag-and-drop:
 
 ![page-design](./img/page-design.png)
 
-In the default deployment, the App Builder is a React JS application served by Node. In a quickstart environment, the App Builder is deployed as a container. It is the frontend of the core application and uses REST APIs to communicate with the core instance and Entando Component Manager (ECM). The App Builder can query the ECM to fetch information on Entando Bundles available to the ECR.
+In the default deployment, the App Builder is a React JS application served by Node. In a quickstart environment, the App Builder is deployed as a container. It is the frontend of the core application and uses REST APIs to communicate with the core instance and [Entando Component Manager (ECM)](ecm-overview.md). The App Builder can query the ECM to fetch information on Entando Bundles available to the ECR.
 
 ### Key Features:
 

--- a/vuepress/docs/next/docs/compose/ecm-overview.md
+++ b/vuepress/docs/next/docs/compose/ecm-overview.md
@@ -4,7 +4,7 @@ sidebarDepth: 2
 
 # Entando Component Manager
 
-​​An Entando Application is composed of the Entando App Builder, [Entando App Engine](../getting-started/concepts-overview.md#entando-app-engine), and Entando Component Manager. The Entando Component Manager (ECM) provides functionality to build and organize micro frontends and widgets from within the App Builder. It also manages the connections between an application and the installed plugins.
+​​An Entando Application is composed of the [Entando App Builder](app-builder.md), [Entando App Engine](../getting-started/concepts-overview.md#entando-app-engine), and Entando Component Manager. The Entando Component Manager (ECM) provides functionality to build and organize micro frontends and widgets from within the App Builder. It also manages the connections between an application and the installed plugins.
 
 The Component Manager is a service that links the [Entando Component Repository](ecr-overview.md) (ECR) of the App Builder to the core application instance. It appears as `quickstart-cm-deployment` in the Kubernetes pod list:
 

--- a/vuepress/docs/v6.3.2/docs/compose/app-builder.md
+++ b/vuepress/docs/v6.3.2/docs/compose/app-builder.md
@@ -14,7 +14,7 @@ Pages are designed and embedded with functionality via drag-and-drop:
 
 ![page-design](./img/page-design.png)
 
-In the default deployment, the App Builder is a React JS application served by Node. In a quickstart environment, the App Builder is deployed as a container. It is the frontend of the core application and uses REST APIs to communicate with the core instance and Entando Component Manager (ECM). The App Builder can query the ECM to fetch information on Entando Bundles available to the ECR.
+In the default deployment, the App Builder is a React JS application served by Node. In a quickstart environment, the App Builder is deployed as a container. It is the frontend of the core application and uses REST APIs to communicate with the core instance and [Entando Component Manager (ECM)](ecm-overview.md). The App Builder can query the ECM to fetch information on Entando Bundles available to the ECR.
 
 ### Key Features:
 

--- a/vuepress/docs/v6.3.2/docs/compose/ecm-overview.md
+++ b/vuepress/docs/v6.3.2/docs/compose/ecm-overview.md
@@ -4,7 +4,7 @@ sidebarDepth: 2
 
 # Entando Component Manager
 
-​​An Entando Application is composed of the Entando App Builder, [Entando App Engine](../getting-started/concepts-overview.md#entando-app-engine), and Entando Component Manager. The Entando Component Manager (ECM) provides functionality to build and organize micro frontends and widgets from within the App Builder. It also manages the connections between an application and the installed plugins.
+​​An Entando Application is composed of the [Entando App Builder](app-builder.md), [Entando App Engine](../getting-started/concepts-overview.md#entando-app-engine), and Entando Component Manager. The Entando Component Manager (ECM) provides functionality to build and organize micro frontends and widgets from within the App Builder. It also manages the connections between an application and the installed plugins.
 
 The Component Manager is a service that links the [Entando Component Repository](ecr-overview.md) (ECR) of the App Builder to the core application instance. It appears as `quickstart-cm-deployment` in the Kubernetes pod list:
 


### PR DESCRIPTION
ecm overview and app builder landing pages were created quasi-simultaneously; valid cross-reference links could not be included until they were committed to main