### PR TITLE
ENDOC-480 update ent 6 or v632 mentions

### DIFF
--- a/vuepress/docs/next/docs/consume/custom-resources.md
+++ b/vuepress/docs/next/docs/consume/custom-resources.md
@@ -15,7 +15,7 @@ Amongst its many features, Kubernetes comes with a REST API for dozens of differ
 Generally these APIs offer full Create/Retrieve/Update/Delete (CRUD) access to each of the resource types. We 
 typically format these resources in YAML or JSON and use commandline tools such as
 `kubectl` or `oc` to manage them. Each of these resources has a clearly defined structure
-that is well documented in the [Kubernetes API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/) .
+that is well documented in the [Kubernetes API](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 Kubernetes  also allows clients to subscribe to events generated as these resources get updated. These subscriptions 
 are called 'watches' and allow clients to be notified whenever the state of a resource changes. It also
 enforces a strong role based access control (RBAC) on all resources, with granular permissions at the level of operation (Create/Retrieve/Update/Delete/Watch) per resource.
@@ -127,8 +127,8 @@ spec:
      H2 database.      
 * `spec.imageName` is used to provide a customized image. By default, the operator will use the `entando/entando-keycloak`
      discussed above. When using the default image, please refer to the
-     [relevant section](https://github.com/entando-k8s/entando-k8s-controller-coordinator/blob/master/charts/entando-k8s-controller-coordinator/README.md#how-it-resolves-docker-images)
-     in the README of the Entando Operator to determine how the Docker registry and version for this image is calculated. 
+     [Docker image section](https://github.com/entando-k8s/entando-k8s-controller-coordinator/blob/master/charts/entando-k8s-controller-coordinator/README.md#how-it-resolves-docker-images)
+     in the README of the Entando Operator to determine how the Docker registry and version for the image is calculated. 
      When you need to customize the theme or add extensions to Keycloak, you can create your own custom image and provide
      the value in this property. Make sure you use the default image (`entando/entando-keycloak`)
      as a base image. You can then add your customizations and build your own. Please use a fully qualified 
@@ -209,7 +209,7 @@ spec:
      
      This property and the `spec.customServerImage` are  assumed to be mutually exclusive. Only provide a value to
      one of the two. Please refer to the 
-     [relevant section](https://github.com/entando-k8s/entando-k8s-controller-coordinator/blob/master/charts/entando-k8s-controller-coordinator/README.md#how-it-resolves-docker-images)
+     [Docker image section](https://github.com/entando-k8s/entando-k8s-controller-coordinator/blob/master/charts/entando-k8s-controller-coordinator/README.md#how-it-resolves-docker-images)
      in the README of the Entando Operator to determine how the Docker registry and version of these images are calculated.
 * `spec.customServerImage` can be used to deploy the Docker image containing your own custom Entando App. Please 
      follow the instructions on how to [build your own image](../../tutorials/devops/build-core-image.md).\

--- a/vuepress/docs/next/docs/reference/entando-cli.md
+++ b/vuepress/docs/next/docs/reference/entando-cli.md
@@ -62,7 +62,7 @@ Use `ent help` to review the list of available commands
 
 > Essentials:
   - Activate using:  ~/.entando/ent/v7.0.0/cli/v7.0.0/activate
-  - Dectivate using: ~/.entando/ent/v6.3.2/cli/v6.3.2/deactivate
+  - Deactivate using: ~/.entando/ent/v7.0.0/cli/v7.0.0/deactivate
 
 > Available commands:
   - app                  => Helper for managing an Entando App
@@ -84,7 +84,7 @@ Use `ent help` to review the list of available commands
   - run-tests            => Runs the internal tests
 
 > Further info about entando:
-  - ~/.entando/ent/quickstart/cli/v7.0.1/README.md
+  - ~/.entando/ent/v7.0.0/cli/v7.0.0/README.md
   - https://www.entando.com/
   - https://developer.entando.com/
 

--- a/vuepress/docs/next/docs/reference/entando-cli.md
+++ b/vuepress/docs/next/docs/reference/entando-cli.md
@@ -61,7 +61,7 @@ Use `ent help` to review the list of available commands
 ~~~~~~~~~~~~~~~~~~~
 
 > Essentials:
-  - Activate using:  ~/.entando/ent/v6.3.2/cli/v6.3.2/activate
+  - Activate using:  ~/.entando/ent/v7.0.0/cli/v7.0.0/activate
   - Dectivate using: ~/.entando/ent/v6.3.2/cli/v6.3.2/deactivate
 
 > Available commands:
@@ -84,7 +84,7 @@ Use `ent help` to review the list of available commands
   - run-tests            => Runs the internal tests
 
 > Further info about entando:
-  - ~/.entando/ent/quickstart/cli/v6.3.2/README.md
+  - ~/.entando/ent/quickstart/cli/v7.0.1/README.md
   - https://www.entando.com/
   - https://developer.entando.com/
 

--- a/vuepress/docs/next/tutorials/create/mfe/widget-configuration.md
+++ b/vuepress/docs/next/tutorials/create/mfe/widget-configuration.md
@@ -1,7 +1,7 @@
 
 # Add a Configuration Screen in App Builder
 
-Entando 6 widgets can be customized through an App Builder configuration screen that is itself a micro frontend. It can be developed and tested in isolation without a running Entando instance.
+Entando widgets can be customized through an App Builder configuration screen that is itself a micro frontend. It can be developed and tested in isolation without a running Entando instance.
 
 ## Create React App
 
@@ -58,7 +58,7 @@ edit `App.js`
         const { name } = this.state;
         return (
           <div>
-            <h1>Sample Entando 6 Widget Configuration</h1>
+            <h1>Sample Entando Widget Configuration</h1>
             <label htmlFor="name">Name</label>
             <input id="name" onChange={e => this.handleNameChange(e.target.value)} value={name} />
           </div>
@@ -112,8 +112,8 @@ Let’s name it `WidgetElement`
 
     export default WidgetElement;
 
-Its responsibility is rendering the react app and syncing the react app
-state in a `config` property, that *must* be named that way. The key to
+Its responsibility is rendering the React app and syncing the React app
+state in a `config` property. That *must* be named that way. The key to
 App Builder communication is that it works in three steps:
 
 -   App Builder reads `config` property when the widget config screen is
@@ -176,12 +176,12 @@ method of `WidgetElement`) and add our new web component tag
 > *must* match the first parameter of the `customElements.define`
 > method.
 
-The page should auto reload and... congrats, you’re running an Entando 6
+The page should auto reload and... congrats, you’re running an Entando
 widget in isolation.
 
 ## Configuration Screen
 
-Next, we’ll build our widget before embedding it into the Entando 6
+Next, we’ll build our widget before embedding it into the Entando 
 instance. From the react project root, type
 
 `npm run build`
@@ -307,7 +307,7 @@ Edit the `App` component now, to make it display the `name` prop.
 
     export default App;
 
-Now, to ensure our custom element is working we can edit
+Now, to ensure our custom element is working, we can edit
 `public/index.html` and set a value for the *name* attribute of the
 custom element.
 
@@ -320,7 +320,7 @@ custom element.
         <title>React App</title>
       </head>
       <body>
-        <my-widget name="Marco"/>
+        <my-widget name="Marco" />
       </body>
     </html>
 

--- a/vuepress/docs/next/tutorials/devops/backing-up-and-restoring-your-environment.md
+++ b/vuepress/docs/next/tutorials/devops/backing-up-and-restoring-your-environment.md
@@ -28,7 +28,7 @@ The output of this step is a local directory with the files (database and static
 | kubectl | OpenShift |
 | ------- | --------- |
 | `kubectl cp <pod>:<path> <local-path>` | `oc rsync <pod>:<path> <localPath>` |
-| e.g. `kubectl cp quickstart-server-deployment-7b8c699599-f84zq:/entando-data backup` | e.g.`oc rsync app-entando-server-deployment-67fd5b9954-s72mb:/entando-data`|
+| e.g. `kubectl cp quickstart-deployment-7b8c699599-f84zq:/entando-data backup` | e.g.`oc rsync app-entando-deployment-67fd5b9954-s72mb:/entando-data`|
 
 5. You should see 3 directories - `databases`, `protected`, and `resources`.
 The `protected` directory contains the timestamped backup you triggered from the App Builder. The `resources` directory contains the static assets. 
@@ -51,7 +51,7 @@ cd entando-de-app
 3. (Optional) Checkout a branch for your desired Entando version. You can review <https://github.com/entando/entando-de-app/releases> to determine the correct tag to use. 
    
 ```sh
-git checkout -b my-test v6.3.68-fix.1
+git checkout -b my-test v7.0.0
 ```
 :::warning
 If you don't perform this step, you'll be creating an Entando Application based on the latest `entando-de-app` code, which may not yet be released.
@@ -68,12 +68,12 @@ mvn clean package
 
 7. Create a Docker image for the application. You'll need to provide your user name and version.
 ```sh
-docker build . -f Dockerfile.wildfly -t <YOUR-USER>/entando-de-app-wildfly:<YOUR-VERSION>
+docker build . -f Dockerfile.wildfly -t YOUR-USER/entando-de-app-wildfly:YOUR-VERSION
 ```
 
 8.  Push the image to Docker
 ```sh
-docker push <YOUR-USER>/entando-de-app-wildfly:<YOUR-VERSION>
+docker push YOUR-USER/entando-de-app-wildfly:YOUR-VERSION
 ```
 
 ### Install the Application
@@ -81,13 +81,13 @@ You can use your typical install steps (or the standard [Manual Install steps](.
 
 1. Retrieve a copy of the `namespace-resources.yaml` for your Entando version
 ```sh
- curl -sfL https://raw.githubusercontent.com/entando/entando-releases/v6.3.2/dist/ge-1-1-6/namespace-scoped-deployment/orig/namespace-resources.yaml > namespace-resources.yaml
+ curl -sfL https://raw.githubusercontent.com/entando/entando-releases/v7.0.1/dist/ge-1-1-6/namespace-scoped-deployment/namespace-resources.yaml > namespace-resources.yaml
 ```
 
 2. Edit `namespace-resources.yaml` and update the `entando-de-app-wildfly` configuration with your user name and version
 ```yaml
 entando-de-app-wildfly: >-
-    {"version":"<YOUR-VERSION>","executable-type":"jvm","registry":"docker.io","organization":"<YOUR-USER>"}
+    {"version":"YOUR-VERSION","executable-type":"jvm","registry":"docker.io","organization":"YOUR-USER"}
 ``` 
 3. Now apply the namespace resources to K8s
 ```sh
@@ -96,4 +96,4 @@ sudo kubectl apply -n entando -f namespace-resources.yaml
 
 4. You can now continue with the rest of the install instructions
 
-5. Once deployed, review the App Builder or running application to confirm the backup was restored correctly. You can check the `server-deployment` logs for possible errors.
+5. Once deployed, review the App Builder or running application to confirm the backup was restored correctly. You can check the deployment logs for possible errors.

--- a/vuepress/docs/next/tutorials/devops/external-id-management.md
+++ b/vuepress/docs/next/tutorials/devops/external-id-management.md
@@ -28,7 +28,7 @@ Specifically you will need:
 -   The Keycloak admin password, e.g. password123
 
 -   The base url for the Keycloak server, including the auth value, e.g.
-    <https://my-keycloak-instance.com/auth>
+    https://your-keycloak-instance.com/auth
 
 ### 2. Generate the secret
 
@@ -42,35 +42,35 @@ Here is an example of the secret you will need to construct:
     ---
     apiVersion: v1
     stringData:
-        username: <the username of the Keycloak admin user for the "entando" realm>
-        password: <the password of this Keycloak admin user>
-        url: <the base url of the Keycloak service, typically ending with the path /auth>
+        username: #the username of the Keycloak admin user for the "entando" realm
+        password: #the password of this Keycloak admin user
+        url: #the base url of the Keycloak service, typically ending with the path /auth
     kind: Secret
     metadata
         name: keycloak-admin-secret
-        namespace: <your-app-namespace>
+        namespace: YOUR-APP-NAMESPACE
     type: Opaque
 
 > **Note**
 >
 > To encode your values, in bash, you can do
-> `echo <your-value> | base64`
+> `echo YOUR-VALUE | base64`
 
 ### 3. Upload the secret
 
 Next upload the secret to the namespace where you want to deploy your
-Entando 6 instance.
+Entando instance.
 
-    oc create -f my-secret.yaml -n <my-app-namespace>
+    oc create -f YOUR-SECRET.yaml -n MY-APP-NAMESPACE
 
-### 4. Deploy the Entando6 application
+### 4. Deploy the Entando application
 
-Now you are ready to deploy your Entando 6 application and the
+Now you are ready to deploy your Entando application and the
 administrator will reuse the *keycloak-admin-secret* secret to populate
 the environment correctly.
 
 ## Conclusion
 
-You should now have a working Entando 6 instance using an external
+You should now have a working Entando instance using an external
 Keycloak server.
 

--- a/vuepress/docs/next/tutorials/devops/invoking-api.md
+++ b/vuepress/docs/next/tutorials/devops/invoking-api.md
@@ -25,7 +25,7 @@ authentication, an access token is returned which grants access to all
 API endpoints and actions for which the authenticated user has defined
 privileges.
 
-(Refer to User Management Roles for details)
+(Refer to [User Management Roles](../../docs/consume/identity-management.md#authorization) for details)
 
 The best way to proceed in case of extensive testing with APIs with
 Postman, is to set up an environment and define a variable that will
@@ -41,7 +41,7 @@ To complete this tutorial you will need:
 
 1.  Postman
 
-2.  A running Entando 6 instance
+2.  A running Entando instance
 
 ## Steps
 
@@ -49,9 +49,9 @@ To complete this tutorial you will need:
 
 Create a new Postman environment and define the following variables:
 
-    access_token: (no value)
-    refresh_token: (no value)
-    url: URL of your application (i.e. http://localhost:8080/entando-de-app)
+    access_token: #no value
+    refresh_token: #no value
+    url: #URL of your application (i.e. http://localhost:8080/entando-de-app)
 
 Be careful with the URL variable and make sure you do not have a
 trailing slash.
@@ -77,16 +77,16 @@ convenience.
 
     Autorization section
        Type: Basic Auth
-       Username: (a valid Entando consumer must be defined in Entando) (Refer to appropriate documentation on how to do that) (i.e. appbuilder)
-       Password: (password of the defined consumer) (i.e. appbuilder_secret)
+       Username: #a valid Entando consumer must be defined in Entando (Refer to appropriate documentation on how to do that) (i.e. appbuilder)
+       Password: #password of the defined consumer (i.e. appbuilder_secret)
 
     Headers section
         Content-Type: application/x-www-form-urlencoded
 
     Body section
     Select from the radio button the option: x-www-form-urlencoded
-        username: (valid Entando user (i.e. admin))
-        password: (password of the valid user)
+        username: #valid Entando user (i.e. admin)
+        password: #password of the valid user
         grant_type: password
 
 The tests section is convenient as we can then set any new API request
@@ -136,13 +136,13 @@ QE has developed a set of collection requests to automate API testing,
 examples of that are available on github at
 <https://github.com/entando/entando-QE/tree/master/postman_API>.
 
-To use them ,first git clone the project and use the built in Postman
+To use them, first git clone the project and use the built in Postman
 importing features.
 
 Import first the Postman Environment file which can be found under the
 environment folder. When imported, from Postman, open in edit that
 environment and change the "url" variable to the appropriate value for
-your specific installation, i.e <http://localhost:8080/entando-de-app/>
+your specific installation, i.e http://localhost:8080/entando-de-app/
 and save it.
 
 Import from Postman the collections you would like to use and they will
@@ -155,12 +155,12 @@ Each collection is so designed to test a particular use case i.e.
 
 By design each QE Postman collection is:
 
--   indipendent (does not require other collections)
+-   independent (does not require other collections)
 
 -   general (does not make any assumption on the specific Entando
     application)
 
--   can be run automatically, with newman, please refer to
+-   can be run automatically, with Newman, please refer to
     <https://github.com/entando/entando-QE> for details
 
 Following those requirements, each collection will need to "prepare" the
@@ -182,7 +182,5 @@ URL, object names, object codes or payloads are usually defined as a
 collection variable and can be accessed by all requests inside the
 collection.
 
-## Conclusion
 
-This guide let you start invoking Entando 6 APIs
 


### PR DESCRIPTION
the check-md errors are from the new EKS install guide which haven't been published yet and don't have these errors.