### PR TITLE
ENDOC-typo correct authentication in sidebar nav

### DIFF
--- a/vuepress/docs/.vuepress/next.js
+++ b/vuepress/docs/.vuepress/next.js
@@ -300,7 +300,7 @@ module.exports = {
                                 path: path + 'create/mfe/widget-configuration.md'
                             },
                             {
-                                title: 'Authentification',
+                                title: 'Authentication',
                                 path: path + 'create/mfe/authentication.md'
                             },
                         ]

--- a/vuepress/docs/.vuepress/v632.js
+++ b/vuepress/docs/.vuepress/v632.js
@@ -284,7 +284,7 @@ module.exports = {
                                 path: path + 'create/mfe/widget-configuration.md'
                             },
                             {
-                                title: 'Authentification',
+                                title: 'Authentication',
                                 path: path + 'create/mfe/authentication.md'
                             },
                         ]

--- a/vuepress/docs/.vuepress/v70.js
+++ b/vuepress/docs/.vuepress/v70.js
@@ -276,7 +276,7 @@ module.exports = {
                                 path: path + 'create/mfe/widget-configuration.md'
                             },
                             {
-                                title: 'Authentification',
+                                title: 'Authentication',
                                 path: path + 'create/mfe/authentication.md'
                             },
                         ]


### PR DESCRIPTION
ironic the branch name has a typo too.

the nav had authentification, instead of authentication as the page is called. Probably my mistake to begin with. 