### PR TITLE
ENDOC-741 copy changes to v7.3

### DIFF
--- a/vuepress/docs/v7.3/docs/curate/bundle-details.md
+++ b/vuepress/docs/v7.3/docs/curate/bundle-details.md
@@ -73,7 +73,7 @@ The following is a list of specifications for the bundle descriptor and its comp
 ### Bundle Descriptor Specifications
 |Name|Type|Required|Description|
 |:-|:-|:-|:-----------------------|
-|`name`|String|Yes|The bundle project name used as the default Docker image name|
+|`name^`|String|Yes|The bundle project name used as the default Docker image name|
 |`description`|String|No|A description of the bundle project shown in the App Builder|
 |`version`|String|Yes|The bundle version used as the default Docker image tag|
 |`displayName`|String|No|A descriptive label used in the UI in place of a name|
@@ -81,6 +81,7 @@ The following is a list of specifications for the bundle descriptor and its comp
 |`microservices`|[Microservices](#microservices-specifications)|No|Bundle microservices|
 |`microfrontends`|[Micro Frontends](#micro-frontends-specifications)|No|Bundle micro frontends|
 
+^ Bundle Name: A bundle name may only contain lowercase letters, numbers, periods(.), and dashes(-). They cannot start or end with periods or dashes.
 ```json
 {
   "name": "my-bundle-name",

--- a/vuepress/docs/v7.3/docs/getting-started/ent-bundle.md
+++ b/vuepress/docs/v7.3/docs/getting-started/ent-bundle.md
@@ -58,6 +58,7 @@ See the [Build and Publish a Simple Bundle](../../tutorials/create/pb/publish-si
 |`ent bundle init [name] --from-hub --hub-url=[url]` | Initialize a bundle from a custom Entando Hub |
 
 #### Init Command Details
+- Bundle names may only contain lowercase letters, numbers, periods(.) and dashes(-). They cannot start or end with periods or dashes.
 - `--from-hub`: This option leverages an existing bundle from an Entando Hub to jumpstart your project. The ent bundle tool will pull the package and rebuild the structure, after which it can be customized locally.
 
 - `--hub-url`: Use this option to specify a custom Entando Hub, else ent defaults to the Entando Cloud Hub
@@ -156,7 +157,7 @@ See the [Build and Publish a Simple Bundle](../../tutorials/create/pb/publish-si
 #### Install Command Details
 * `ent bundle install --conflict-strategy=OVERRIDE`: If a bundle project has already been installed, the `--conflict-strategy` flag forces a `CREATE`, `SKIP` or `OVERRIDE` strategy for components
 
-## Convert v1 to v5
+### Convert v1 to v5
 
 | Command| Descriptions
 |:--|:--


### PR DESCRIPTION
just copying previous update to v7.3. Luca C said the bundle name validation is only for 7.3.