### PR TITLE
Fix 'resources' type description

### DIFF
--- a/vuepress/docs/v7.3/docs/curate/bundle-details.md
+++ b/vuepress/docs/v7.3/docs/curate/bundle-details.md
@@ -106,7 +106,7 @@ The following is a list of specifications for the bundle descriptor and its comp
 |`ingressPath`|String|No||Custom ingress path for health check|
 |`name`|String|Yes||Microservice name|
 |`permissions`|[Permission[]](#permission-specification)|No| | List of permissions to grant to the microservice |
-|`resources`|[resources[]](#microservices-resources)| No | | Requested resources for storage, memory and CPU |
+|`resources`|[resources](#microservices-resources)| No | | Requested resources for storage, memory and CPU |
 |`roles`|String[]|No||Exposed security roles|
 |`stack`|Enum|Yes|*spring-boot<br/>*node<br/>*custom|Microservice stack |
 |`version`|String|Required only for a custom stack||Microservice version override|


### PR DESCRIPTION
## Summary:

This pull request addresses the discrepancy in the type definition for the resources field in the microservice model. The current implementation uses an array type, which causes issues during deployment. The correct type should be a plain JSON object.

## Details:

The ent CLI does not perform any validation on the microservice model during `pack` execution, leading to potential errors during deployment.

## Examples:

##### Example 1:

```json

{
      "name": "testms",
      "stack": "custom",
      "dbms": "postgresql",
      "healthCheckPath": "/api/health",
      "commands": {
        "build": "...",
        "run": "...",
        "pack": "..."
      },
      "version": "0.0.5",
      "resources": [  // valid, no errors during pack phase
        {"cpu": "100m"},
        {"memory": "128M"}
      ]
}
```
##### Example 2:

```json

{
      "name": "testms",
      "stack": "custom",
      "dbms": "postgresql",
      "healthCheckPath": "/api/health",
      "commands": {
        "build": "...",
        "run": "...",
        "pack": "..."
      },
      "version": "0.0.5",
      "resources": {  // valid, no errors during pack phase
        "cpu": "100m",
        "memory": "128M"
      }
}
```
Both examples work during the pack phase. However, if the deployed bundle is installed with the microservice defined as in Example 1, the error "plugin/testms.yaml invalid [...]" appears when clicking the install button in AppBuilder. On the other hand, the deployed bundle with the microservice defined as in Example 2 will also fail:

The "cm" pod logs a null pointer exception due to the missing "storage" parameter in the "resources" object. Could this parameter be made optional? Some containers do not require storage.
<details>

<summary>NPE detail</summary>

```
java.lang.NullPointerException: null
	at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1770) ~[na:na]
	at java.base/java.util.regex.Matcher.reset(Matcher.java:416) ~[na:na]
	at java.base/java.util.regex.Matcher.<init>(Matcher.java:253) ~[na:na]
	at java.base/java.util.regex.Pattern.matcher(Pattern.java:1134) ~[na:na]
	at org.entando.kubernetes.validator.descriptor.PluginDescriptorValidator.validatePluginResourcePropOrThrow(PluginDescriptorValidator.java:381) ~[classes!/:7.3.0-SNAPSHOT]
	at org.entando.kubernetes.validator.descriptor.PluginDescriptorValidator.validatePluginResources(PluginDescriptorValidator.java:366) ~[classes!/:7.3.0-SNAPSHOT]
	at org.entando.kubernetes.validator.descriptor.BaseDescriptorValidator.lambda$validateOrThrow$0(BaseDescriptorValidator.java:91) ~[classes!/:7.3.0-SNAPSHOT]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
```

</details>

## Changes:

  -  Corrected the type of the resources field to a plain JSON object to ensure consistency and avoid deployment errors.